### PR TITLE
Implement path aliases

### DIFF
--- a/client/eslint_extend.js
+++ b/client/eslint_extend.js
@@ -21,6 +21,7 @@ export default {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" } ],
     "no-trailing-spaces": "warn",
-    "object-curly-spacing": ["warn", "always"]
+    "object-curly-spacing": ["warn", "always"],
+    "@typescript-eslint/consistent-type-imports": "warn"
   },
 };

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@eslint/js": "^9.13.0",
         "@hookform/devtools": "^4.3.1",
+        "@types/node": "^22.9.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
@@ -5165,6 +5166,16 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.8"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -10301,6 +10312,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -14301,6 +14319,15 @@
         "@types/lodash": "*"
       }
     },
+    "@types/node": {
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.8"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -17600,6 +17627,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "update-browserslist-db": {
       "version": "1.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@eslint/js": "^9.13.0",
     "@hookform/devtools": "^4.3.1",
+    "@types/node": "^22.9.0",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,17 +1,18 @@
-import { ReactElement, StrictMode } from "react";
+import type { ReactElement } from "react";
+import { StrictMode } from "react";
 import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import HomePage from "./pages/Home/Home";
-import PrivateLayout from "./layouts/Private/Private";
-import PlaygroundPage from "./pages/Playground/Playground";
-import LoginPage from "./pages/Login/Login";
-import MainLayout from "./layouts/Main";
-import AuthLayout from "./layouts/Auth";
-import ReservationsManagementPage from "./pages/ReservationsManagement/ReservationsManagement";
-import TablesManagementPage from "./pages/TablesManagement/TablesManagement";
+import HomePage from "@pages/Home/Home";
+import PrivateLayout from "@layouts/Private/Private";
+import PlaygroundPage from "@pages/Playground/Playground";
+import LoginPage from "@pages/Login/Login";
+import MainLayout from "@layouts/Main";
+import AuthLayout from "@layouts/Auth";
+import ReservationsManagementPage from "@pages/ReservationsManagement/ReservationsManagement";
+import TablesManagementPage from "@pages/TablesManagement/TablesManagement";
 
 const router = createBrowserRouter([
   {

--- a/client/src/components/Avatar/Company.tsx
+++ b/client/src/components/Avatar/Company.tsx
@@ -1,5 +1,5 @@
 import { User } from "@nextui-org/react";
-import { CompanyData } from "../../core/types";
+import type { CompanyData } from "@core/types";
 
 export default function CompanyAvatar(props: { company: CompanyData }) {
   const { name, description } = props.company;

--- a/client/src/components/Avatar/User.tsx
+++ b/client/src/components/Avatar/User.tsx
@@ -1,5 +1,5 @@
 import { DropdownTrigger, User } from "@nextui-org/react";
-import { UserData } from "../../core/types";
+import type { UserData } from "@core/types";
 
 export default function UserAvatar(props: { user: UserData }) {
   const { name, surname, username } = props.user;

--- a/client/src/components/DrawerMenu/DrawerMenu.tsx
+++ b/client/src/components/DrawerMenu/DrawerMenu.tsx
@@ -1,15 +1,15 @@
 import { Button } from "@nextui-org/react";
-import { ReactElement } from "react";
-import MenuCloseIcon from "../Icons/MenuCloseIcon";
-import MenuOpenIcon from "../Icons/MenuOpenIcon";
+import type { ReactElement } from "react";
+import MenuCloseIcon from "@components/Icons/MenuCloseIcon";
+import MenuOpenIcon from "@components/Icons/MenuOpenIcon";
 import { useLocation, useNavigate } from "react-router-dom";
-import HomeIcon from "../Icons/HomeIcon";
-import PlaygroundIcon from "../Icons/PlaygroundIcon";
-import SettingsIcon from "../Icons/SettingsIcon";
-import CompanyAvatar from "../Avatar/Company";
-import { useDrawer } from "../../context/Drawer";
-import TableClockIcon from "../Icons/TableClockIcon";
-import TableIcon from "../Icons/TableIcon";
+import HomeIcon from "@components/Icons/HomeIcon";
+import PlaygroundIcon from "@components/Icons/PlaygroundIcon";
+import SettingsIcon from "@components/Icons/SettingsIcon";
+import CompanyAvatar from "@components/Avatar/Company";
+import { useDrawer } from "@context/Drawer";
+import TableClockIcon from "@components/Icons/TableClockIcon";
+import TableIcon from "@components/Icons/TableIcon";
 
 export default function DrawerMenu(): ReactElement {
   const navigate = useNavigate();

--- a/client/src/components/Fields/Calendar.tsx
+++ b/client/src/components/Fields/Calendar.tsx
@@ -1,4 +1,5 @@
-import { Calendar, DateValue } from "@nextui-org/react";
+import type { DateValue } from "@nextui-org/react";
+import { Calendar } from "@nextui-org/react";
 import { today, getLocalTimeZone, CalendarDate } from "@internationalized/date";
 import { Controller } from "react-hook-form";
 

--- a/client/src/components/Fields/CalendarPlain.tsx
+++ b/client/src/components/Fields/CalendarPlain.tsx
@@ -1,4 +1,5 @@
-import { Calendar, CalendarProps } from "@nextui-org/react";
+import type { CalendarProps } from "@nextui-org/react";
+import { Calendar } from "@nextui-org/react";
 import { Controller } from "react-hook-form";
 
 type Props = {

--- a/client/src/components/Fields/Checkbox.tsx
+++ b/client/src/components/Fields/Checkbox.tsx
@@ -1,4 +1,5 @@
-import { Checkbox, CheckboxProps } from "@nextui-org/react";
+import type { CheckboxProps } from "@nextui-org/react";
+import { Checkbox } from "@nextui-org/react";
 import { useFormContext } from "react-hook-form";
 
 type Props = {

--- a/client/src/components/Fields/ColorPicker.tsx
+++ b/client/src/components/Fields/ColorPicker.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@nextui-org/react";
 import classNames from "classnames";
-import { createContext, PropsWithChildren, ReactElement, useContext } from "react";
+import type { PropsWithChildren, ReactElement } from "react";
+import { createContext, useContext } from "react";
 import { Controller } from "react-hook-form";
 
 type Props = {

--- a/client/src/components/Fields/Email.tsx
+++ b/client/src/components/Fields/Email.tsx
@@ -1,8 +1,8 @@
-import { ReactElement } from "react";
-import InputField from "./Input";
-import { RegisterOptions } from "react-hook-form";
-import { ControlledInputProps } from "./types";
-import { MailIcon } from "../Icons/MailIcon";
+import type { ReactElement } from "react";
+import InputField from "@components/Fields/Input";
+import type { RegisterOptions } from "react-hook-form";
+import type { ControlledInputProps } from "@components/Fields/types";
+import { MailIcon } from "@components/Icons/MailIcon";
 
 export default function EmailField(props: Omit<ControlledInputProps, "type">): ReactElement {
   const defaultRules: RegisterOptions = {
@@ -14,9 +14,7 @@ export default function EmailField(props: Omit<ControlledInputProps, "type">): R
 
   return (
     <InputField
-      endContent={
-        <MailIcon className="text-2xl text-default-400 pointer-events-none flex-shrink-0" />
-      }
+      endContent={<MailIcon className="text-2xl text-default-400 pointer-events-none flex-shrink-0" />}
       {...props}
       type="email"
       rules={defaultRules}

--- a/client/src/components/Fields/Input.tsx
+++ b/client/src/components/Fields/Input.tsx
@@ -1,8 +1,9 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 import { Input } from "@nextui-org/react";
-import { RegisterOptions, useFormContext } from "react-hook-form";
-import { getError, hasError } from "../../core/utils";
-import { ControlledInputProps } from "./types";
+import type { RegisterOptions } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
+import { getError, hasError } from "@core/utils";
+import type { ControlledInputProps } from "@components/Fields/types";
 
 export default function InputField(props: ControlledInputProps): ReactElement {
     const { name, isRequired, rules, maxLength, minLength, label, ...otherProps } = props;

--- a/client/src/components/Fields/Number.tsx
+++ b/client/src/components/Fields/Number.tsx
@@ -1,7 +1,7 @@
-import { ReactElement } from "react";
-import InputField from "./Input";
-import { RegisterOptions } from "react-hook-form";
-import { ControlledInputProps } from "./types";
+import type { ReactElement } from "react";
+import InputField from "@components/Fields/Input";
+import type { RegisterOptions } from "react-hook-form";
+import type { ControlledInputProps } from "@components/Fields/types";
 
 export default function NumberField(props: Omit<ControlledInputProps, "type">): ReactElement {
 

--- a/client/src/components/Fields/Password.tsx
+++ b/client/src/components/Fields/Password.tsx
@@ -1,10 +1,12 @@
-import { ReactElement, useState } from "react";
+import type { ReactElement } from "react";
+import { useState } from "react";
 import { Input } from "@nextui-org/react";
-import { RegisterOptions, useFormContext } from "react-hook-form";
-import { getError, hasError } from "../../core/utils";
-import { ControlledInputProps } from "./types";
-import { EyeSlashFilledIcon } from "../Icons/EyeSlashFilledIcon";
-import { EyeFilledIcon } from "../Icons/EyeFilledIcon";
+import type { RegisterOptions } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
+import { getError, hasError } from "@core/utils";
+import type { ControlledInputProps } from "@components/Fields/types";
+import { EyeSlashFilledIcon } from "@components/Icons/EyeSlashFilledIcon";
+import { EyeFilledIcon } from "@components/Icons/EyeFilledIcon";
 
 /**
  * @todo Implement password validation

--- a/client/src/components/Fields/ReservationTime.tsx
+++ b/client/src/components/Fields/ReservationTime.tsx
@@ -1,9 +1,9 @@
+import type { ReactElement } from "react";
 import { Time } from "@internationalized/date";
 import { AccessTime } from "@mui/icons-material";
 import { SelectItem } from "@nextui-org/react";
-import { ReactElement } from "react";
-import SelectField from "./Select";
-import { OperationalTime } from "../../core/types";
+import SelectField from "@components/Fields/Select";
+import type { OperationalTime } from "@core/types";
 
 type Props = {
   name: string;

--- a/client/src/components/Fields/Select.tsx
+++ b/client/src/components/Fields/Select.tsx
@@ -1,7 +1,7 @@
+import type { ReactElement } from "react";
 import { Select } from "@nextui-org/react";
-import { ReactElement } from "react";
 import { Controller } from "react-hook-form";
-import { ControlledSelectProps } from "./types";
+import type { ControlledSelectProps } from "@components/Fields/types";
 
 export default function SelectField(props: ControlledSelectProps): ReactElement {
   const { children, defaultSelectedKeys, name, ...rest } = props;

--- a/client/src/components/Fields/StatusGroup.tsx
+++ b/client/src/components/Fields/StatusGroup.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@nextui-org/react";
-import { ReservationStatus } from "../../core/types";
+import type { ReservationStatus } from "@core/types";
 
 /** @todo This could be a nice status changer */
 export default function StatusGroupField(props: { status: ReservationStatus } ) {

--- a/client/src/components/Fields/Time.tsx
+++ b/client/src/components/Fields/Time.tsx
@@ -1,9 +1,10 @@
 import { Time } from "@internationalized/date";
 import { AccessTime } from "@mui/icons-material";
-import { SelectItem, SelectProps } from "@nextui-org/react";
-import { ReactElement } from "react";
-import SelectField from "./Select";
-import { OperationalTime } from "../../core/types";
+import type { SelectProps } from "@nextui-org/react";
+import { SelectItem } from "@nextui-org/react";
+import type { ReactElement } from "react";
+import SelectField from "@components/Fields/Select";
+import type { OperationalTime } from "@core/types";
 
 type Props = {
   name: string;

--- a/client/src/components/Fields/types.ts
+++ b/client/src/components/Fields/types.ts
@@ -1,6 +1,6 @@
-import { InputProps } from "@nextui-org/input";
-import { SelectProps } from "@nextui-org/react";
-import { RegisterOptions } from "react-hook-form";
+import type { InputProps } from "@nextui-org/input";
+import type { SelectProps } from "@nextui-org/react";
+import type { RegisterOptions } from "react-hook-form";
 
 export type ControlledInputProps = {
   name: string;

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
-import { Divider, Image } from "@nextui-org/react";
-import { ReactElement } from "react";
-import logo from "../../assets/images/logo.png";
+import type { ReactElement } from "react";
 import { Link } from "react-router-dom";
+import { Divider, Image } from "@nextui-org/react";
+import logo from "@assets/images/logo.png";
 
 export default function Footer(): ReactElement {
   return (

--- a/client/src/components/Grid/GridDndContext.tsx
+++ b/client/src/components/Grid/GridDndContext.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import React from "react";
+import type {
+  PointerActivationConstraint,
+  Modifiers } from "@dnd-kit/core";
 import {
   DndContext,
   useSensor,
   MouseSensor,
   TouchSensor,
-  PointerActivationConstraint,
-  Modifiers,
   useSensors
-} from '@dnd-kit/core';
+} from "@dnd-kit/core";
 
-import { Normalized, TableData } from '../../core/types';
-import { GridTableDraggable } from './GridTableDraggable';
+import type { Normalized, TableData } from "@core/types";
+import { GridTableDraggable } from "@components/Grid/GridTableDraggable";
 
 interface Props {
   activationConstraint?: PointerActivationConstraint;

--- a/client/src/components/Grid/GridTable.tsx
+++ b/client/src/components/Grid/GridTable.tsx
@@ -1,4 +1,4 @@
-import { gridSize, gridItemMultiplierHeight, gridItemMultiplierWidth, gridItemGap } from "../../settings.json";
+import { gridSize, gridItemMultiplierHeight, gridItemMultiplierWidth, gridItemGap } from "@settings";
 
 export default function GridTable({ color, label, capacity }: { color: string; label: string; capacity: number }) {
   const buttonStyle = {

--- a/client/src/components/Grid/GridTableDraggable.tsx
+++ b/client/src/components/Grid/GridTableDraggable.tsx
@@ -1,14 +1,16 @@
-import { DragEndEvent, UniqueIdentifier, useDndMonitor, useDraggable } from "@dnd-kit/core";
-import { TableData } from "../../core/types";
+import type { DragEndEvent, UniqueIdentifier } from "@dnd-kit/core";
+import { useDndMonitor, useDraggable } from "@dnd-kit/core";
+import type { TableData } from "@core/types";
 import classNames from "classnames";
-import styles from '../DragNDrop/TableDraggable/TableDraggable.module.css';
+import styles from '@components/DragNDrop/TableDraggable/TableDraggable.module.css';
 import { Link } from "react-router-dom";
-import { EditIcon } from "../Icons/EditIcon";
-import { gridSize, gridItemMultiplierHeight, gridItemMultiplierWidth, gridItemGap } from "../../settings.json";
-import { Key, useEffect, useState } from "react";
-import { Coordinates } from "@dnd-kit/core/dist/types";
-import { client } from "../../core/request";
-import EditTableModal from "../Modal/EditTable";
+import { EditIcon } from "@components/Icons/EditIcon";
+import { gridSize, gridItemMultiplierHeight, gridItemMultiplierWidth, gridItemGap } from "@settings";
+import type { Key } from "react";
+import { useEffect, useState } from "react";
+import type { Coordinates } from "@dnd-kit/core/dist/types";
+import { client } from "@core/request";
+import EditTableModal from "@components/Modal/EditTable";
 import { useDisclosure } from "@nextui-org/react";
 
 type Props = {

--- a/client/src/components/Modal/AddTable.tsx
+++ b/client/src/components/Modal/AddTable.tsx
@@ -1,21 +1,23 @@
-import { TableData } from "../../core/types";
+import { useState } from "react";
+import type { TableData } from "@core/types";
+import type {
+  useDisclosure } from "@nextui-org/react";
 import {
   Button,
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
-  useDisclosure,
+  ModalHeader
 } from "@nextui-org/react";
-import { FieldValues, FormProvider, useForm } from "react-hook-form";
-import InputField from "../Fields/Input";
-import NumberField from "../Fields/Number";
-import { useState } from "react";
-import { client } from "../../core/request";
-import ColorPickerField, { ColorPickerOption } from "../Fields/ColorPicker";
-import GridTable from "../Grid/GridTable";
-import { Coordinates } from "@dnd-kit/core/dist/types";
+import type { FieldValues } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import InputField from "@components/Fields/Input";
+import NumberField from "@components/Fields/Number";
+import { client } from "@core/request";
+import ColorPickerField, { ColorPickerOption } from "@components/Fields/ColorPicker";
+import GridTable from "@components/Grid/GridTable";
+import type { Coordinates } from "@dnd-kit/core/dist/types";
 
 export default function AddTableModal(props: ReturnType<typeof useDisclosure> & { defaultCoordinates: Coordinates }) {
   const { isOpen, onOpenChange, onClose: close, defaultCoordinates } = props;

--- a/client/src/components/Modal/CancelReservation.tsx
+++ b/client/src/components/Modal/CancelReservation.tsx
@@ -1,9 +1,10 @@
-import { useDisclosure } from "@nextui-org/react";
-import ConfirmationModal from "./Confirmation";
-import { ReservationData, ReservationStatus } from "../../core/types";
+import type { useDisclosure } from "@nextui-org/react";
+import ConfirmationModal from "@components/Modal/Confirmation";
+import type { ReservationData } from "@core/types";
+import { ReservationStatus } from "@core/types";
 import { useState } from "react";
-import { client } from "../../core/request";
-import { getFullName } from "../../core/utils";
+import { client } from "@core/request";
+import { getFullName } from "@core/utils";
 
 type Props = {
   reservation: ReservationData;

--- a/client/src/components/Modal/ConfirmReservation.tsx
+++ b/client/src/components/Modal/ConfirmReservation.tsx
@@ -1,9 +1,10 @@
-import { useDisclosure } from "@nextui-org/react";
-import ConfirmationModal from "./Confirmation";
-import { ReservationData, ReservationStatus } from "../../core/types";
+import type { useDisclosure } from "@nextui-org/react";
+import ConfirmationModal from "@components/Modal/Confirmation";
+import type { ReservationData } from "@core/types";
+import { ReservationStatus } from "@core/types";
 import { useState } from "react";
-import { client } from "../../core/request";
-import { getFullName } from "../../core/utils";
+import { client } from "@core/request";
+import { getFullName } from "@core/utils";
 
 type Props = {
   reservation: ReservationData;

--- a/client/src/components/Modal/Confirmation.tsx
+++ b/client/src/components/Modal/Confirmation.tsx
@@ -1,5 +1,6 @@
-import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button, useDisclosure, ButtonProps } from "@nextui-org/react";
-import { ReactElement } from "react";
+import type { useDisclosure, ButtonProps } from "@nextui-org/react";
+import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button } from "@nextui-org/react";
+import type { ReactElement } from "react";
 
 type Props = {
   body: string | ReactElement;

--- a/client/src/components/Modal/CreateReservation.tsx
+++ b/client/src/components/Modal/CreateReservation.tsx
@@ -1,14 +1,16 @@
-import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, useDisclosure } from "@nextui-org/react";
-import { FieldValues, FormProvider, useForm } from "react-hook-form";
-import InputField from "../Fields/Input";
-import NumberField from "../Fields/Number";
-import CalendarPlainField from "../Fields/CalendarPlain";
-import CheckboxField from "../Fields/Checkbox";
-import EmailField from "../Fields/Email";
+import type { useDisclosure } from "@nextui-org/react";
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from "@nextui-org/react";
+import type { FieldValues } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import InputField from "@components/Fields/Input";
+import NumberField from "@components/Fields/Number";
+import CalendarPlainField from "@components/Fields/CalendarPlain";
+import CheckboxField from "@components/Fields/Checkbox";
+import EmailField from "@components/Fields/Email";
 import { useState } from "react";
-import { client } from "../../core/request";
-import TimeField from "../Fields/Time";
-import { ReservationStatus } from "../../core/types";
+import { client } from "@core/request";
+import TimeField from "@components/Fields/Time";
+import { ReservationStatus } from "@core/types";
 import { today } from "@internationalized/date";
 
 type Props = ReturnType<typeof useDisclosure>;

--- a/client/src/components/Modal/EditReservation.tsx
+++ b/client/src/components/Modal/EditReservation.tsx
@@ -1,16 +1,18 @@
-import { ReservationData } from "../../core/types";
-import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, useDisclosure } from "@nextui-org/react";
-import { getFullName } from "../../core/utils";
-import { FieldValues, FormProvider, useForm } from "react-hook-form";
-import InputField from "../Fields/Input";
-import NumberField from "../Fields/Number";
-import CalendarPlainField from "../Fields/CalendarPlain";
-import { parseDate } from "@internationalized/date";
-import CheckboxField from "../Fields/Checkbox";
-import EmailField from "../Fields/Email";
 import { useState } from "react";
-import { client } from "../../core/request";
-import TimeField from "../Fields/Time";
+import type { ReservationData } from "@core/types";
+import type { useDisclosure } from "@nextui-org/react";
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from "@nextui-org/react";
+import { getFullName } from "@core/utils";
+import type { FieldValues } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import InputField from "@components/Fields/Input";
+import NumberField from "@components/Fields/Number";
+import CalendarPlainField from "@components/Fields/CalendarPlain";
+import { parseDate } from "@internationalized/date";
+import CheckboxField from "@components/Fields/Checkbox";
+import EmailField from "@components/Fields/Email";
+import { client } from "@core/request";
+import TimeField from "@components/Fields/Time";
 
 type Props = {
   reservation: ReservationData;

--- a/client/src/components/Modal/EditTable.tsx
+++ b/client/src/components/Modal/EditTable.tsx
@@ -1,12 +1,14 @@
-import { TableData } from "../../core/types";
-import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, useDisclosure } from "@nextui-org/react";
-import { FieldValues, FormProvider, useForm } from "react-hook-form";
-import InputField from "../Fields/Input";
-import NumberField from "../Fields/Number";
 import { useState } from "react";
-import { client } from "../../core/request";
-import ColorPickerField, { ColorPickerOption } from "../Fields/ColorPicker";
-import GridTable from "../Grid/GridTable";
+import type { TableData } from "@core/types";
+import type { useDisclosure } from "@nextui-org/react";
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from "@nextui-org/react";
+import type { FieldValues } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import InputField from "@components/Fields/Input";
+import NumberField from "@components/Fields/Number";
+import { client } from "@core/request";
+import ColorPickerField, { ColorPickerOption } from "@components/Fields/ColorPicker";
+import GridTable from "@components/Grid/GridTable";
 
 type Props = {
   table: TableData;

--- a/client/src/components/Modal/RemoveReservation.tsx
+++ b/client/src/components/Modal/RemoveReservation.tsx
@@ -1,9 +1,9 @@
-import { useDisclosure } from "@nextui-org/react";
-import ConfirmationModal from "./Confirmation";
-import { ReservationData } from "../../core/types";
+import type { useDisclosure } from "@nextui-org/react";
+import ConfirmationModal from "@components/Modal/Confirmation";
+import type { ReservationData } from "@core/types";
 import { useState } from "react";
-import { client } from "../../core/request";
-import { getFullName } from "../../core/utils";
+import { client } from "@core/request";
+import { getFullName } from "@core/utils";
 
 type Props = {
   reservation: ReservationData;

--- a/client/src/components/Navigation/Navigation.tsx
+++ b/client/src/components/Navigation/Navigation.tsx
@@ -1,9 +1,9 @@
+import type { ReactElement } from "react";
 import { Navbar, NavbarBrand, NavbarContent, NavbarItem, Button, Image } from "@nextui-org/react";
-import logo from "../../assets/images/logo.png";
+import logo from "@assets/images/logo.png";
 import { useNavigate } from "react-router-dom";
-import { ReactElement } from "react";
-import { useAuth } from "../../context/Authentication";
-import UserMenu from "../UserMenu/UserMenu";
+import { useAuth } from "@context/Authentication";
+import UserMenu from "@components/UserMenu/UserMenu";
 
 export default function Navigation() {
   const navigate = useNavigate();

--- a/client/src/components/PageHeader/PageHeader.tsx
+++ b/client/src/components/PageHeader/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 
 type Props = {
   heading: string;

--- a/client/src/components/Reservations/Actions.tsx
+++ b/client/src/components/Reservations/Actions.tsx
@@ -1,11 +1,12 @@
 import { Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Button, DropdownSection, useDisclosure } from "@nextui-org/react";
-import MenuDotsIcon from "../Icons/MenuDotsIcon";
-import { ReservationData, ReservationStatus } from "../../core/types";
-import { Key, ReactElement } from "react";
-import EditReservationModal from "../Modal/EditReservation";
-import RemoveReservationModal from "../Modal/RemoveReservation";
-import CancelReservationModal from "../Modal/CancelReservation";
-import ConfirmReservationModal from "../Modal/ConfirmReservation";
+import MenuDotsIcon from "@components/Icons/MenuDotsIcon";
+import type { ReservationData } from "@core/types";
+import { ReservationStatus } from "@core/types";
+import type { Key, ReactElement } from "react";
+import EditReservationModal from "@components/Modal/EditReservation";
+import RemoveReservationModal from "@components/Modal/RemoveReservation";
+import CancelReservationModal from "@components/Modal/CancelReservation";
+import ConfirmReservationModal from "@components/Modal/ConfirmReservation";
 
 type Props = {
   reservation: ReservationData;

--- a/client/src/components/Reservations/Table.tsx
+++ b/client/src/components/Reservations/Table.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useMemo, useState } from "react";
 import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, User, DatePicker, Input, Spinner, Pagination, Button, useDisclosure } from "@nextui-org/react";
-import Status from "../Status/Status";
 import { parseDate, parseTime } from "@internationalized/date";
-import { ReservationData } from "../../core/types";
-import ReservationsActions from "./Actions";
-import { getFullName } from "../../core/utils";
-import useGetReservations from "../../hooks/useGetReservations";
-import AddIcon from "../Icons/AddIcon";
-import CreateReservationModal from "../Modal/CreateReservation";
+import Status from "@components/Status/Status";
+import type { ReservationData } from "@core/types";
+import ReservationsActions from "@components/Reservations/Actions";
+import { getFullName } from "@core/utils";
+import useGetReservations from "@hooks/useGetReservations";
+import AddIcon from "@components/Icons/AddIcon";
+import CreateReservationModal from "@components/Modal/CreateReservation";
 
 const columns = [
   { name: "NAME", uid: "name" },

--- a/client/src/components/Status/Status.tsx
+++ b/client/src/components/Status/Status.tsx
@@ -1,6 +1,6 @@
+import type { ReactElement } from "react";
 import { Chip } from "@nextui-org/react";
-import { ReactElement } from "react";
-import { ReservationStatus } from "../../core/types";
+import { ReservationStatus } from "@core/types";
 
 type Props = {
     status: ReservationStatus | undefined

--- a/client/src/components/TablesGrid/TablesGrid.tsx
+++ b/client/src/components/TablesGrid/TablesGrid.tsx
@@ -1,13 +1,14 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { CSSProperties, Key, ReactElement } from "react";
 import { createSnapModifier, restrictToFirstScrollableAncestor } from "@dnd-kit/modifiers";
-import { GridDndContext } from "../Grid/GridDndContext";
-import { CSSProperties, Key, ReactElement, useCallback, useMemo, useRef, useState } from "react";
-import useGetTables from "../../hooks/useGetTables";
-import { isUndefined, normalize } from "../../core/utils";
+import { GridDndContext } from "@components/Grid/GridDndContext";
+import useGetTables from "@hooks/useGetTables";
+import { isUndefined, normalize } from "@core/utils";
 import { Button, Dropdown, DropdownItem, DropdownMenu, DropdownTrigger, Spinner, useDisclosure } from "@nextui-org/react";
-import { TableData } from "../../core/types";
-import AddIcon from "../Icons/AddIcon";
-import { PointerActivationConstraint } from "@dnd-kit/core";
-import AddTableModal from "../Modal/AddTable";
+import type { TableData } from "@core/types";
+import AddIcon from "@components/Icons/AddIcon";
+import type { PointerActivationConstraint } from "@dnd-kit/core";
+import AddTableModal from "@components/Modal/AddTable";
 
 type Props = {
   size: number;

--- a/client/src/components/UserMenu/UserMenu.tsx
+++ b/client/src/components/UserMenu/UserMenu.tsx
@@ -1,8 +1,8 @@
 import { Dropdown, DropdownItem, DropdownMenu } from "@nextui-org/react";
-import { ReactElement } from "react";
-import { useAuth } from "../../context/Authentication";
-import { UserData } from "../../core/types";
-import UserAvatar from "../Avatar/User";
+import type { ReactElement } from "react";
+import { useAuth } from "@context/Authentication";
+import type { UserData } from "@core/types";
+import UserAvatar from "@components/Avatar/User";
 
 type Props = {
   user: UserData

--- a/client/src/context/Authentication.tsx
+++ b/client/src/context/Authentication.tsx
@@ -1,9 +1,10 @@
-import { createContext, PropsWithChildren, useContext, useEffect, useState } from "react"
-import { client } from "../core/request";
+import type { PropsWithChildren } from "react";
+import { createContext, useContext, useEffect, useState } from "react"
+import { client } from "@core/request";
 import { useNavigate } from "react-router-dom";
-import { ensureErr, sleep } from "../core/utils";
+import { ensureErr, sleep } from "@core/utils";
 import { AxiosError } from "axios";
-import { AuthValue, Credentials, UserData } from "../core/types";
+import type { AuthValue, Credentials, UserData } from "@core/types";
 
 const AuthContext = createContext<AuthValue | null>(null);
 

--- a/client/src/context/Drawer.tsx
+++ b/client/src/context/Drawer.tsx
@@ -1,5 +1,6 @@
-import { createContext, PropsWithChildren, useContext, useState } from "react"
-import settings from "../settings.json";
+import type { PropsWithChildren } from "react";
+import { createContext, useContext, useState } from "react"
+import settings from "@settings";
 
 type ContextProps = {
   open: boolean;

--- a/client/src/core/utils.ts
+++ b/client/src/core/utils.ts
@@ -1,5 +1,5 @@
-import { FieldValues, FormState } from "react-hook-form";
-import { HasId, Normalized, UserData } from "./types";
+import type { FieldValues, FormState } from "react-hook-form";
+import type { HasId, Normalized, UserData } from "@core/types";
 
 /**
  * Checks if field has any errors

--- a/client/src/hooks/useGetReservations.tsx
+++ b/client/src/hooks/useGetReservations.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { client } from "../core/request";
-import { ReservationData } from "../core/types";
+import { client } from "@core/request";
+import type { ReservationData } from "@core/types";
 import { HttpStatusCode } from "axios";
-import { equals } from "../core/utils";
+import { equals } from "@core/utils";
 
 /**
  * @todo Implement such hooks using TanStack Query

--- a/client/src/hooks/useGetTables.tsx
+++ b/client/src/hooks/useGetTables.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { client } from "../core/request";
-import { TableData } from "../core/types";
+import { client } from "@core/request";
+import type { TableData } from "@core/types";
 import { HttpStatusCode } from "axios";
-import { equals } from "../core/utils";
+import { equals } from "@core/utils";
 
 /**
  * @todo Implement such hooks using TanStack Query

--- a/client/src/layouts/Auth.tsx
+++ b/client/src/layouts/Auth.tsx
@@ -1,6 +1,6 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 import { Outlet } from "react-router-dom";
-import AuthProvider from "../context/Authentication";
+import AuthProvider from "@context/Authentication";
 
 export default function AuthLayout(): ReactElement {
   return (

--- a/client/src/layouts/Main.tsx
+++ b/client/src/layouts/Main.tsx
@@ -1,7 +1,7 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 import { Outlet } from "react-router-dom";
-import Navigation from "../components/Navigation/Navigation";
-import Footer from "../components/Footer/Footer";
+import Navigation from "@components/Navigation/Navigation";
+import Footer from "@components/Footer/Footer";
 
 export default function MainLayout(): ReactElement {
   return (

--- a/client/src/layouts/Private/MainContent.tsx
+++ b/client/src/layouts/Private/MainContent.tsx
@@ -1,8 +1,8 @@
 import { Outlet } from "react-router-dom";
-import DrawerMenu from "../../components/DrawerMenu/DrawerMenu";
-import Navigation from "../../components/Navigation/Navigation";
-import Footer from "../../components/Footer/Footer";
-import { useDrawer } from "../../context/Drawer";
+import DrawerMenu from "@components/DrawerMenu/DrawerMenu";
+import Navigation from "@components/Navigation/Navigation";
+import Footer from "@components/Footer/Footer";
+import { useDrawer } from "@context/Drawer";
 
 export default function MainContent() {
   const { open } = useDrawer();

--- a/client/src/layouts/Private/Private.tsx
+++ b/client/src/layouts/Private/Private.tsx
@@ -1,8 +1,8 @@
-import { ReactElement } from "react";
+import type { ReactElement } from "react";
 import { Navigate } from "react-router-dom";
-import { useAuth } from "../../context/Authentication";
-import DrawerProvider from "../../context/Drawer";
-import MainContent from "./MainContent";
+import { useAuth } from "@context/Authentication";
+import DrawerProvider from "@context/Drawer";
+import MainContent from "@layouts/Private/MainContent";
 
 export default function PrivateLayout(): ReactElement {
   const auth = useAuth();

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -1,5 +1,5 @@
-import { ReactElement } from "react";
-import PageHeader from "../../components/PageHeader/PageHeader";
+import type { ReactElement } from "react";
+import PageHeader from "@components/PageHeader/PageHeader";
 
 export default function HomePage(): ReactElement {
   return <PageHeader heading="Home page" subheading="Nothing here yet..." />

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -1,12 +1,13 @@
-import { ReactElement } from "react";
-import { Button, Link } from "@nextui-org/react";
-import { FieldValues, FormProvider, useForm } from "react-hook-form";
-import PasswordField from "../../components/Fields/Password";
-import { DevTool } from "@hookform/devtools";
-import EmailField from "../../components/Fields/Email";
-import { useAuth } from "../../context/Authentication";
+import type { ReactElement } from "react";
 import { Navigate, useLocation } from "react-router-dom";
-import PageHeader from "../../components/PageHeader/PageHeader";
+import type { FieldValues } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import { Button, Link } from "@nextui-org/react";
+import PasswordField from "@components/Fields/Password";
+import { DevTool } from "@hookform/devtools";
+import EmailField from "@components/Fields/Email";
+import { useAuth } from "@context/Authentication";
+import PageHeader from "@components/PageHeader/PageHeader";
 
 /**
  * @todo Convert to modal instead of page

--- a/client/src/pages/Playground/Playground.tsx
+++ b/client/src/pages/Playground/Playground.tsx
@@ -1,15 +1,16 @@
+import type { ReactElement } from "react";
+import type { FieldValues } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { Button, SelectItem } from "@nextui-org/react";
-import { ReactElement } from "react";
-import ReservationTimeField from "../../components/Fields/ReservationTime";
-import InputField from "../../components/Fields/Input";
-import { FieldValues, FormProvider, useForm } from "react-hook-form";
+import ReservationTimeField from "@components/Fields/ReservationTime";
+import InputField from "@components/Fields/Input";
 import { DevTool } from "@hookform/devtools";
-import EmailField from "../../components/Fields/Email";
-import CalendarField from "../../components/Fields/Calendar";
-import CheckboxField from "../../components/Fields/Checkbox";
-import NumberField from "../../components/Fields/Number";
-import SelectField from "../../components/Fields/Select";
-import PageHeader from "../../components/PageHeader/PageHeader";
+import EmailField from "@components/Fields/Email";
+import CalendarField from "@components/Fields/Calendar";
+import CheckboxField from "@components/Fields/Checkbox";
+import NumberField from "@components/Fields/Number";
+import SelectField from "@components/Fields/Select";
+import PageHeader from "@components/PageHeader/PageHeader";
 
 export default function PlaygroundPage(): ReactElement {
 

--- a/client/src/pages/ReservationsManagement/ReservationsManagement.tsx
+++ b/client/src/pages/ReservationsManagement/ReservationsManagement.tsx
@@ -1,6 +1,6 @@
-import { ReactElement } from "react";
-import PageHeader from "../../components/PageHeader/PageHeader";
-import DataTable from "../../components/Reservations/Table";
+import type { ReactElement } from "react";
+import PageHeader from "@components/PageHeader/PageHeader";
+import DataTable from "@components/Reservations/Table";
 
 export default function ReservationsManagementPage(): ReactElement {
   return (

--- a/client/src/pages/TablesManagement/TablesManagement.tsx
+++ b/client/src/pages/TablesManagement/TablesManagement.tsx
@@ -1,7 +1,7 @@
-import { ReactElement } from "react";
-import PageHeader from "../../components/PageHeader/PageHeader";
-import TablesGrid from "../../components/TablesGrid/TablesGrid";
-import config from "../../settings.json";
+import type { ReactElement } from "react";
+import PageHeader from "@components/PageHeader/PageHeader";
+import TablesGrid from "@components/TablesGrid/TablesGrid";
+import config from "@settings";
 
 const GRID_SIZE = config.gridSize;
 

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -18,7 +18,19 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    
+    /* Path aliases */
+    "paths": {
+      "@assets/*": ["./src/assets/*"],
+      "@components/*": ["./src/components/*"],
+      "@context/*": ["./src/context/*"],
+      "@core/*": ["./src/core/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@layouts/*": ["./src/layouts/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@settings": ["./src/settings.json"]
+    }
   },
   "include": ["src"]
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,10 +1,23 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolve } from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000
+  },
+  resolve: {
+    alias: {
+      "@assets": resolve(__dirname, "./src/assets"),
+      "@components": resolve(__dirname, "./src/components"),
+      "@context": resolve(__dirname, "./src/context"),
+      "@core": resolve(__dirname, "./src/core"),
+      "@hooks": resolve(__dirname, "./src/hooks"),
+      "@layouts": resolve(__dirname, "./src/layouts"),
+      "@pages": resolve(__dirname, "./src/pages"),
+      "@settings": resolve(__dirname, "./src/settings.json"),
+    }
   }
 })


### PR DESCRIPTION
## Description

- Added eslint rule `consistent-type-imports`
- Introduced path aliases
- Swapped relative import paths from all files, with path aliases

## Example
```typescript
// before
import InputField from "../../../components/Fields/Input";

// after
import InputField from "@components/Fields/Input";
```
