### PR TITLE
Remove comments from application.properties file due to unsupported c…

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -3,9 +3,9 @@ spring.application.name=estiator.io
 spring.jpa.hibernate.ddl-auto=update
 
 # --- CHANGE THIS ACCORDING TO DATABASE CONFIGURATION
-spring.datasource.url=jdbc:mysql://localhost:3306/# INSERT DATABASE NAME
-spring.datasource.username= # DATABASE USERNAME
-spring.datasource.password= # DATABASE PASSWORD
+spring.datasource.url=jdbc:mysql://localhost:3306/
+spring.datasource.username=
+spring.datasource.password=
 # ---
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.show-sql=true


### PR DESCRIPTION
## Description
Comments related to the database name, username, and password have been removed from `application.properties`. Although comments in that specific location were unsupported, the code editor did not explicitly indicate their disallowance.