### PR TITLE
Improve getflags script

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "estiator.io",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^7.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "postinstall": "node scripts/getflags.js",
     "dev": "vite",
     "dev:expose": "vite --host",
     "styles:build": "tailwindcss -i ./src/input.css -o ./build/output.css",


### PR DESCRIPTION
## Description 
- Added `getflags` script to `postinstall` to fetch flags after installing packages
- Improved `getFlags` script for better management of operations. 
- Added individual `getFlag` request delay to prevent parallelism and remote server rejections