### PR TITLE
Implement Customers Management page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import UnauthorizedOnlyLayout from "@layouts/UnauthorizedOnly";
 import CommonLayout from "@layouts/Common";
 import { UserRole } from "@core/types";
 import NotificationProvider from "@context/Notification";
+import CustomerManagementPage from "@pages/CustomerManagement/CustomerManagement";
 
 const router = createBrowserRouter([
   {
@@ -39,6 +40,10 @@ const router = createBrowserRouter([
           {
             path: "tables-management",
             element: <TablesManagementPage />
+          },
+          {
+            path: "customers-management",
+            element: <CustomerManagementPage />
           }
         ],
       },

--- a/client/src/components/Avatar/User.tsx
+++ b/client/src/components/Avatar/User.tsx
@@ -1,5 +1,6 @@
 import { DropdownTrigger, User } from "@heroui/react";
 import type { UserData } from "@core/types";
+import { getInitials } from "@core/utils";
 
 export default function UserAvatar(props: { user: UserData }) {
   const { name, surname, email } = props.user;
@@ -10,14 +11,12 @@ export default function UserAvatar(props: { user: UserData }) {
         as="button"
         avatarProps={{
           isBordered: true,
-          name: `${name.charAt(0).toUpperCase()} ${surname
-            .charAt(0)
-            .toUpperCase()}`,
-          }}
-          classNames={{ name: "max-md:hidden", description: "max-md:hidden" }}
-          className="transition-transform"
-          description={email}
-          name={`${name} ${surname}`}
+          name: getInitials(props.user)
+        }}
+        classNames={{ name: "max-md:hidden", description: "max-md:hidden" }}
+        className="transition-transform"
+        description={email}
+        name={`${name} ${surname}`}
       />
     </DropdownTrigger>
   );

--- a/client/src/components/Customers/Actions.tsx
+++ b/client/src/components/Customers/Actions.tsx
@@ -1,0 +1,68 @@
+import { Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Button, DropdownSection, useDisclosure } from "@heroui/react";
+import MenuDotsIcon from "@components/Icons/MenuDotsIcon";
+import type { UserData } from "@core/types";
+import { UserRole } from "@core/types";
+import type { Key } from "react";
+import { userIsAllowed } from "@core/auth";
+import { useAuth } from "@context/Authentication";
+import RemoveCustomerModal from "@components/Modal/RemoveCustomer";
+import EditCustomerModal from "@components/Modal/EditCustomer";
+
+type Props = {
+  customer: UserData;
+}
+
+enum Action {
+  EDIT = "edit",
+  REMOVE = "remove"
+};
+
+export default function CustomersActions(props: Props) {
+  const customer = props.customer;
+
+  const edit = useDisclosure();
+  const remove = useDisclosure();
+
+  const auth = useAuth();
+  const user = auth?.user;
+  const isAllowed = userIsAllowed(user, [UserRole.ADMIN]);
+
+  function handleAction(key: Key) {
+    switch(key) {
+      case Action.EDIT:
+        edit.onOpen();
+        break;
+      case Action.REMOVE:
+        remove.onOpen();
+        break;
+    }
+  }
+
+  return (
+    <>
+      <Dropdown>
+        <DropdownTrigger>
+          <Button isIconOnly variant="light">
+            <MenuDotsIcon className="text-2xl" />
+          </Button>
+        </DropdownTrigger>
+        <DropdownMenu
+          aria-label="Action event example"
+          variant="solid"
+          onAction={handleAction}>
+          <DropdownSection title="Manage">
+            <DropdownItem key={Action.EDIT}>Edit customer</DropdownItem>
+          </DropdownSection>
+          {isAllowed ? <DropdownSection title="Danger zone">
+            <DropdownItem key={Action.REMOVE} className="text-danger" color="danger">
+              Remove
+            </DropdownItem> 
+          </DropdownSection> : null}
+        </DropdownMenu>
+      </Dropdown>
+      <RemoveCustomerModal customer={customer} {...remove} />
+      <EditCustomerModal customer={customer} {...edit} />
+      {/* <RemoveReservationModal customer={customer} {...remove} /> */}
+    </>
+  );
+}

--- a/client/src/components/Customers/Actions.tsx
+++ b/client/src/components/Customers/Actions.tsx
@@ -56,13 +56,12 @@ export default function CustomersActions(props: Props) {
           {isAllowed ? <DropdownSection title="Danger zone">
             <DropdownItem key={Action.REMOVE} className="text-danger" color="danger">
               Remove
-            </DropdownItem> 
+            </DropdownItem>
           </DropdownSection> : null}
         </DropdownMenu>
       </Dropdown>
       <RemoveCustomerModal customer={customer} {...remove} />
       <EditCustomerModal customer={customer} {...edit} />
-      {/* <RemoveReservationModal customer={customer} {...remove} /> */}
     </>
   );
 }

--- a/client/src/components/Customers/Table.tsx
+++ b/client/src/components/Customers/Table.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
-import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, User, DatePicker, Spinner, Pagination, Button, useDisclosure, Chip, Input } from "@heroui/react";
+import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, User, DatePicker, Spinner, Pagination, Chip, Input } from "@heroui/react";
 import { UserRole, UserRoleName, type UserData } from "@core/types";
-import AddIcon from "@components/Icons/AddIcon";
-import CreateReservationModal from "@components/Modal/CreateReservation";
 import { getFullName, parseTimestamp } from "@core/utils";
 import useQueryCustomers from "@hooks/useQueryCustomers";
 import CustomersActions from "./Actions";
@@ -20,7 +18,6 @@ export default function CustomersTable() {
   const [page, setPage] = useState(1);
   const rowsPerPage = 10;
   const pages = customers ? Math.ceil(customers.length / rowsPerPage) : 0;
-  const createDisclosure = useDisclosure();
 
   const items = useMemo(() => {
     const start = (page - 1) * rowsPerPage;
@@ -33,7 +30,6 @@ export default function CustomersTable() {
     return (
       <div className="flex flex-row justify-between items-end">
         <p className="text-xs text-default-600">{count! > 0 && `Total customers: ${customers?.length}`}</p>
-        <Button color="primary" onPress={createDisclosure.onOpen}><AddIcon className="text-md" />Add customer</Button>
       </div>
     )
   }, [customers?.length]);
@@ -98,34 +94,31 @@ export default function CustomersTable() {
   }, [customers]);
 
   return (
-    <>
-      <Table
-        topContentPlacement="outside"
-        topContent={topContent}
-        aria-label="Customers table"
-        bottomContent={bottomContent}
-        bottomContentPlacement="outside"
+    <Table
+      topContentPlacement="outside"
+      topContent={topContent}
+      aria-label="Customers table"
+      bottomContent={bottomContent}
+      bottomContentPlacement="outside"
+    >
+      <TableHeader columns={columns}>
+        {(column) => (
+          <TableColumn
+            key={column.uid}
+            align={column.uid === "actions" ? "center" : "start"}
+          >
+            {column.name}
+          </TableColumn>
+        )}
+      </TableHeader>
+      <TableBody
+          emptyContent={<p>No reservations to display</p>}
+          isLoading={!Array.isArray(customers)}
+          items={items || []}
+          loadingContent={<Spinner label="Loading..." />}
       >
-        <TableHeader columns={columns}>
-          {(column) => (
-            <TableColumn
-              key={column.uid}
-              align={column.uid === "actions" ? "center" : "start"}
-            >
-              {column.name}
-            </TableColumn>
-          )}
-        </TableHeader>
-        <TableBody
-            emptyContent={<p>No reservations to display</p>}
-            isLoading={!Array.isArray(customers)}
-            items={items || []}
-            loadingContent={<Spinner label="Loading..." />}
-        >
-          {(customer: UserData) => renderRow(customer)}
-        </TableBody>
-      </Table>
-      <CreateReservationModal {...createDisclosure} />
-    </>
+        {(customer: UserData) => renderRow(customer)}
+      </TableBody>
+    </Table>
   );
 }

--- a/client/src/components/Customers/Table.tsx
+++ b/client/src/components/Customers/Table.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useMemo, useState } from "react";
+import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, User, DatePicker, Spinner, Pagination, Button, useDisclosure, Chip, Input } from "@heroui/react";
+import { UserRole, UserRoleName, type UserData } from "@core/types";
+import AddIcon from "@components/Icons/AddIcon";
+import CreateReservationModal from "@components/Modal/CreateReservation";
+import { getFullName, parseTimestamp } from "@core/utils";
+import useQueryCustomers from "@hooks/useQueryCustomers";
+import CustomersActions from "./Actions";
+
+const columns = [
+  { name: "NAME", uid: "name" },
+  { name: "PHONE", uid: "phone" },
+  { name: "ROLE", uid: "role" },
+  { name: "CREATED AT", uid: "createdAT" },
+  { name: "ACTIONS", uid: "actions" }
+];
+
+export default function CustomersTable() {
+  const { data: customers } = useQueryCustomers(500);
+  const [page, setPage] = useState(1);
+  const rowsPerPage = 10;
+  const pages = customers ? Math.ceil(customers.length / rowsPerPage) : 0;
+  const createDisclosure = useDisclosure();
+
+  const items = useMemo(() => {
+    const start = (page - 1) * rowsPerPage;
+    const end = start + rowsPerPage;
+    return customers?.slice(start, end);
+  }, [page, customers]);
+
+  const topContent = useMemo(() => {
+    const count = customers?.length;
+    return (
+      <div className="flex flex-row justify-between items-end">
+        <p className="text-xs text-default-600">{count! > 0 && `Total customers: ${customers?.length}`}</p>
+        <Button color="primary" onPress={createDisclosure.onOpen}><AddIcon className="text-md" />Add customer</Button>
+      </div>
+    )
+  }, [customers?.length]);
+
+  const bottomContent = useMemo(() => {
+    if (!customers || customers.length == 0) {
+      return;
+    }
+
+    return (
+      <div className="flex justify-center">
+          <Pagination
+            showControls
+            showShadow
+            color="primary"
+            variant="flat"
+            page={page}
+            total={pages}
+            onChange={(page) => setPage(page)}
+          />
+      </div>
+    )
+  }, [items, customers]);
+
+  const renderRow = useCallback((customer: UserData) => {
+    const createdDate = parseTimestamp(customer.createdDate);
+
+    return (
+      <TableRow>
+        <TableCell className="w-[25%]" textValue="Date">
+          <User
+            avatarProps={{ radius: "full", size: "sm" }}
+            classNames={{
+              description: "text-default-500",
+            }}
+            description={customer.email || customer.phone}
+            name={getFullName(customer)}
+          />
+        </TableCell>
+        <TableCell className="w-[15%]">
+          <Input value={customer.phone} />
+        </TableCell>
+        <TableCell className="w-[10%]">
+          <Chip variant="flat" color={customer.userRole === UserRole.GUEST ? "default" : "secondary"} >{UserRoleName[customer.userRole]}</Chip>
+        </TableCell>
+        <TableCell className="w-[20%]" textValue="Created at">
+          <DatePicker
+            isReadOnly
+            aria-label="Date"
+            className="max-w-xs"
+            granularity="day"
+            value={createdDate}
+          />
+        </TableCell>
+        <TableCell className="w-1/12" textValue="Actions">
+          <div>
+            <CustomersActions customer={customer} />
+          </div>
+        </TableCell>
+      </TableRow>
+    );
+  }, [customers]);
+
+  return (
+    <>
+      <Table
+        topContentPlacement="outside"
+        topContent={topContent}
+        aria-label="Customers table"
+        bottomContent={bottomContent}
+        bottomContentPlacement="outside"
+      >
+        <TableHeader columns={columns}>
+          {(column) => (
+            <TableColumn
+              key={column.uid}
+              align={column.uid === "actions" ? "center" : "start"}
+            >
+              {column.name}
+            </TableColumn>
+          )}
+        </TableHeader>
+        <TableBody
+            emptyContent={<p>No reservations to display</p>}
+            isLoading={!Array.isArray(customers)}
+            items={items || []}
+            loadingContent={<Spinner label="Loading..." />}
+        >
+          {(customer: UserData) => renderRow(customer)}
+        </TableBody>
+      </Table>
+      <CreateReservationModal {...createDisclosure} />
+    </>
+  );
+}

--- a/client/src/components/Customers/Table.tsx
+++ b/client/src/components/Customers/Table.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
-import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, User, DatePicker, Spinner, Pagination, Chip, Input } from "@heroui/react";
+import { Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, User, DatePicker, Spinner, Pagination, Chip, Input, Button } from "@heroui/react";
 import { UserRole, UserRoleName, type UserData } from "@core/types";
 import { getFullName, parseTimestamp } from "@core/utils";
 import useQueryCustomers from "@hooks/useQueryCustomers";
 import CustomersActions from "./Actions";
+import AddIcon from "@components/Icons/AddIcon";
+import { useNavigate } from "react-router-dom";
 
 const columns = [
   { name: "NAME", uid: "name" },
@@ -18,6 +20,7 @@ export default function CustomersTable() {
   const [page, setPage] = useState(1);
   const rowsPerPage = 10;
   const pages = customers ? Math.ceil(customers.length / rowsPerPage) : 0;
+  const navigate = useNavigate();
 
   const items = useMemo(() => {
     const start = (page - 1) * rowsPerPage;
@@ -30,6 +33,7 @@ export default function CustomersTable() {
     return (
       <div className="flex flex-row justify-between items-end">
         <p className="text-xs text-default-600">{count! > 0 && `Total customers: ${customers?.length}`}</p>
+        <Button onPress={() => navigate("/register")} color="primary"><AddIcon className="text-md" />Register user</Button>
       </div>
     )
   }, [customers?.length]);

--- a/client/src/components/DrawerMenu/DrawerMenu.tsx
+++ b/client/src/components/DrawerMenu/DrawerMenu.tsx
@@ -58,6 +58,7 @@ export default function DrawerMenu(): ReactElement {
           <AdminOnly>
             <DrawerItem to="/employees-management" text="Employees Management" icon={<PersonIcon className="text-xl" />} />
           </AdminOnly>
+          <DrawerItem to="/customers-management" text="Customers Management" icon={<PersonIcon className="text-xl" />} />
         </div>
 
         <div className="flex flex-col gap-2">

--- a/client/src/components/Employees/EmployeeInfo/EmployeeInfo.tsx
+++ b/client/src/components/Employees/EmployeeInfo/EmployeeInfo.tsx
@@ -5,7 +5,7 @@ import BackIcon from "@components/Icons/BackIcon";
 import { DeleteIcon } from "@components/Icons/DeleteIcon";
 import ConfirmationModal from "@components/Modal/Confirmation";
 import Status from "@components/Status/Employee/Status";
-import { UserRole, UserStatus, type UserData } from "@core/types";
+import { UserRole, UserRoleName, UserStatus, type UserData } from "@core/types";
 import { deleteReq, formatDateTime, parseTimestamp, patchReq } from "@core/utils";
 import { SelectItem, Button, Image, useDisclosure, Avatar } from "@heroui/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -168,7 +168,7 @@ export default function EmployeeInfo(props: {
                   {Object.values(UserRole).map((item: UserRole) => {
                     return (
                       <SelectItem key={item} value={item}>
-                        {item}
+                        {UserRoleName[item]}
                       </SelectItem>
                     );
                   })}

--- a/client/src/components/Employees/EmployeeInfo/EmployeeInfo.tsx
+++ b/client/src/components/Employees/EmployeeInfo/EmployeeInfo.tsx
@@ -6,7 +6,7 @@ import { DeleteIcon } from "@components/Icons/DeleteIcon";
 import ConfirmationModal from "@components/Modal/Confirmation";
 import Status from "@components/Status/Employee/Status";
 import { UserRole, UserRoleName, UserStatus, type UserData } from "@core/types";
-import { deleteReq, formatDateTime, parseTimestamp, patchReq } from "@core/utils";
+import { deleteReq, formatDateTime, getInitials, parseTimestamp, patchReq } from "@core/utils";
 import { SelectItem, Button, Image, useDisclosure, Avatar } from "@heroui/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { type ReactElement } from "react";
@@ -78,7 +78,7 @@ export default function EmployeeInfo(props: {
   }
 
   function getFallbackSrc(employee: UserData) {
-    return `https://ui-avatars.com/api/?size=300&name=${employee.name}+${employee.surname}`
+    return `https://ui-avatars.com/api/?size=300&name=${getInitials(employee)}`
   }
 
   return (
@@ -94,9 +94,7 @@ export default function EmployeeInfo(props: {
                   isBordered
                   src={employee.profileImage}
                   className="w-16 h-16 text-large mr-1"
-                  name={`${employee.name.charAt(0).toUpperCase()} ${employee.surname
-                    .charAt(0)
-                    .toUpperCase()}`}
+                  name={getInitials(employee)}
               />
               <div>
                 <h1 className="text-2xl">

--- a/client/src/components/Employees/EmployeesList.tsx
+++ b/client/src/components/Employees/EmployeesList.tsx
@@ -1,9 +1,8 @@
 import BuildingIcon from "@components/Icons/BuildingIcon";
-import MailIcon from "@components/Icons/MailIcon";
 import IconSuitcase from "@components/Icons/SuitcaseIcon";
 import Status from "@components/Status/Employee/Status";
-import type { UserData } from "@core/types";
-import { formatDateTime, parseTimestamp } from "@core/utils";
+import { UserRoleName, type UserData } from "@core/types";
+import { formatDateTime, getInitials, parseTimestamp } from "@core/utils";
 import useQueryEmployees from "@hooks/useQueryEmployees";
 import { Avatar, Card, CardBody, CardHeader } from "@heroui/react";
 import { Link } from "react-router-dom";
@@ -29,19 +28,15 @@ export default function EmployeesList() {
                   isBordered
                   src={employee.profileImage}
                   className="w-20 h-20 text-large mb-3"
-                  name={`${employee.name.charAt(0).toUpperCase()} ${employee.surname
-                    .charAt(0)
-                    .toUpperCase()}`}
-                    />
+                  name={getInitials(employee)} />
                 <h4>{`${employee.name} ${employee.surname}`}</h4>
-                <p className="text-foreground-400 text-sm">{employee.userRole}</p>
+                <p className="text-foreground-400 text-sm"><a href={`mailto:${employee.email}`} className="break-all">{employee.email}</a></p>
                 <div className="bg-content2 rounded-lg p-3 mt-3 border-1 shadow-inner shadow-slate-100 border-slate-200 w-full">
                   <ul className="flex gap-2 flex-col">
                     <ul className="inline-flex items-center gap-2">
-                      <li className="inline-flex items-center text-xs gap-1"><IconSuitcase />{employee.userRole}</li>
-                      <li className="inline-flex items-center text-xs gap-1"><BuildingIcon />{employee.position}</li>
+                      <li className="inline-flex items-center text-xs gap-1"><BuildingIcon />{UserRoleName[employee.userRole]}</li>
+                      {employee.position && <li className="inline-flex items-center text-xs gap-1"><IconSuitcase />{employee.position}</li>}
                     </ul>
-                    <li className="inline-flex items-center text-xs gap-1"><MailIcon /><a href={`mailto:${employee.email}`} className="break-all">{employee.email}</a></li>
                   </ul>
                 </div>
                 <div className="flex text-xs flex-row justify-between w-full items-center mt-2">

--- a/client/src/components/Modal/EditCustomer.tsx
+++ b/client/src/components/Modal/EditCustomer.tsx
@@ -44,8 +44,6 @@ export default function EditCustomerModal(props: Props) {
         userRole: values.userRole,
         inform: values.inform
       };
-      console.log(data);
-      return;
       await patchReq(`/users/${customer.id}`, { ...data });
       notify({ message: "Customer info have been updated successfully!", type: "success" });
     } catch (error) {

--- a/client/src/components/Modal/EditCustomer.tsx
+++ b/client/src/components/Modal/EditCustomer.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import type { UserData } from "@core/types";
+import type { useDisclosure } from "@heroui/react";
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from "@heroui/react";
+import { getFullName, patchReq } from "@core/utils";
+import type { FieldValues } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import InputField from "@components/Fields/Input";
+import CheckboxField from "@components/Fields/Checkbox";
+import EmailField from "@components/Fields/Email";
+import { useNotification } from "@context/Notification";
+import PhoneCodeField from "@components/Fields/PhoneCode";
+
+type Props = {
+  customer: UserData;
+} & ReturnType<typeof useDisclosure>;
+
+export default function EditCustomerModal(props: Props) {
+  const { customer, isOpen, onOpenChange, onClose } = props;
+  const [loading, setLoading] = useState(false);
+  const { notify } = useNotification();
+
+  const methods = useForm({
+    mode: "onChange",
+    defaultValues: {
+      name: customer.name,
+      surname: customer.surname,
+      email: customer.email,
+      countryCode: [customer.phone?.split(" ")[0]],
+      phone: customer.phone?.split(" ")[1],
+    }
+  });
+
+  async function onSubmit(values: FieldValues): Promise<void> {
+    try {
+      setLoading(true);
+      const data = {
+        name: values.name,
+        surname: values.surname,
+        email: values.email,
+        phone: `${values.countryCode} ${values.phone}`,
+        inform: values.inform
+      };
+      await patchReq(`/users/${customer.id}`, { ...data });
+      notify({ message: "Customer info have been updated successfully!", type: "success" });
+    } catch (error) {
+      console.error(error);
+      notify({ message: "Customer info could not be updated.", type: "danger" });
+    } finally {
+      setLoading(false);
+      onClose();
+    }
+  }
+
+  return (
+    <Modal
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        placement="top"
+        size="2xl"
+        backdrop="opaque"
+        onClose={methods.reset}
+      >
+        <ModalContent>
+          {(onClose) => (
+            <FormProvider {...methods}>
+              <form onSubmit={methods.handleSubmit(onSubmit)}>
+              <ModalHeader className="gap-1">
+                Editing customer of <em>{getFullName(customer)}</em><br />
+              </ModalHeader>
+              <ModalBody>
+              <div className="gap-4 md:flex">
+                <div className="w-full md:w-3/4 md:flex-grow flex flex-col gap-2">
+                  <InputField isRequired label="Name" name="name"  />
+                  <InputField isRequired label="Surname" name="surname" />
+                  <EmailField isRequired label="Email" name="email" />
+                  <div className="flex flex-nowrap basis-full">
+                    <div className="basis-2/6 p-1">
+                      <PhoneCodeField name="countryCode" label="Country code" />
+                    </div>
+                    <div className="basis-4/6 p-1">
+                      <InputField
+                        name="phone"
+                        label="Phone number"
+                        maxLength={64}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <CheckboxField label="Inform client about the changes (requires user email)" name="inform" />
+              </ModalBody>
+              <ModalFooter>
+                <Button color="default" variant="light" onPress={onClose}>
+                  Cancel
+                </Button>
+                <Button color="primary" type="submit" isLoading={loading}>
+                  Update customer
+                </Button>
+              </ModalFooter>
+              </form>
+            </FormProvider>
+          )}
+        </ModalContent>
+      </Modal>
+    )
+}

--- a/client/src/components/Modal/EditCustomer.tsx
+++ b/client/src/components/Modal/EditCustomer.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import type { UserData } from "@core/types";
+import { UserRole, UserRoleName, type UserData } from "@core/types";
 import type { useDisclosure } from "@heroui/react";
-import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from "@heroui/react";
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, SelectItem } from "@heroui/react";
 import { getFullName, patchReq } from "@core/utils";
 import type { FieldValues } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
@@ -10,6 +10,7 @@ import CheckboxField from "@components/Fields/Checkbox";
 import EmailField from "@components/Fields/Email";
 import { useNotification } from "@context/Notification";
 import PhoneCodeField from "@components/Fields/PhoneCode";
+import SelectField from "@components/Fields/Select";
 
 type Props = {
   customer: UserData;
@@ -28,6 +29,7 @@ export default function EditCustomerModal(props: Props) {
       email: customer.email,
       countryCode: [customer.phone?.split(" ")[0]],
       phone: customer.phone?.split(" ")[1],
+      userRole: customer.userRole
     }
   });
 
@@ -39,8 +41,11 @@ export default function EditCustomerModal(props: Props) {
         surname: values.surname,
         email: values.email,
         phone: `${values.countryCode} ${values.phone}`,
+        userRole: values.userRole,
         inform: values.inform
       };
+      console.log(data);
+      return;
       await patchReq(`/users/${customer.id}`, { ...data });
       notify({ message: "Customer info have been updated successfully!", type: "success" });
     } catch (error) {
@@ -74,6 +79,10 @@ export default function EditCustomerModal(props: Props) {
                   <InputField isRequired label="Name" name="name"  />
                   <InputField isRequired label="Surname" name="surname" />
                   <EmailField isRequired label="Email" name="email" />
+                  <SelectField name="userRole" label="Role">
+                    <SelectItem key={UserRole.CLIENT} value={UserRole.CLIENT}>{UserRoleName[UserRole.CLIENT]}</SelectItem>
+                    <SelectItem key={UserRole.GUEST} value={UserRole.GUEST}>{UserRoleName[UserRole.GUEST]}</SelectItem>
+                  </SelectField>
                   <div className="flex flex-nowrap basis-full">
                     <div className="basis-2/6 p-1">
                       <PhoneCodeField name="countryCode" label="Country code" />

--- a/client/src/components/Modal/RemoveCustomer.tsx
+++ b/client/src/components/Modal/RemoveCustomer.tsx
@@ -1,0 +1,48 @@
+import type { useDisclosure } from "@heroui/react";
+import ConfirmationModal from "@components/Modal/Confirmation";
+import type { UserData } from "@core/types";
+import { useState } from "react";
+import { deleteReq, getFullName } from "@core/utils";
+import { useNotification } from "@context/Notification";
+
+type Props = {
+  customer: UserData;
+} & ReturnType<typeof useDisclosure>;
+
+export default function RemoveCustomerModal(props: Props) {
+  const { customer, ...disclosureProps } = props;
+  const [loading, setLoading] = useState(false);
+  const { notify } = useNotification();
+
+  async function handleAction() {
+    try {
+      setLoading(true);
+      await deleteReq(`/users/${customer.id}`);
+      notify({ message: "Customer has been deleted successfully!", type: "success" });
+    } catch (error) {
+      console.error(error);
+      notify({ message: "Customer could not be deleted", type: "danger" });
+    } finally {
+      setLoading(false);
+      disclosureProps.onClose();
+    }
+  }
+
+  return (
+    <ConfirmationModal
+      {...disclosureProps}
+      title="Remove customer"
+      cancelText="Abort"
+      confirmText="Remove"
+      confirmButtonProps={{ color: "danger", isLoading: loading }}
+      body={
+        <p>
+          Customer {getFullName(customer)} will be <strong>removed.</strong>
+          <br />
+          Are you sure you want to continue?
+        </p>
+      }
+      callback={handleAction}
+    />
+  );
+}

--- a/client/src/components/Reservations/Table.tsx
+++ b/client/src/components/Reservations/Table.tsx
@@ -141,7 +141,7 @@ export default function ReservationsTable() {
       <Table
         topContentPlacement="outside"
         topContent={topContent}
-        aria-label="Example table with custom cells"
+        aria-label="Reservations table"
         bottomContent={bottomContent}
         bottomContentPlacement="outside"
       >

--- a/client/src/context/Authentication.tsx
+++ b/client/src/context/Authentication.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren } from "react";
-import { createContext, useContext, useState } from "react"
-import { client } from "@core/request";
+import { createContext, useContext } from "react"
 import { useNavigate } from "react-router-dom";
 import { ensureErr, postReq } from "@core/utils";
 import { AxiosError } from "axios";

--- a/client/src/context/Authentication.tsx
+++ b/client/src/context/Authentication.tsx
@@ -2,36 +2,32 @@ import type { PropsWithChildren } from "react";
 import { createContext, useContext, useState } from "react"
 import { client } from "@core/request";
 import { useNavigate } from "react-router-dom";
-import { ensureErr } from "@core/utils";
+import { ensureErr, postReq } from "@core/utils";
 import { AxiosError } from "axios";
 import type { AuthValue, Credentials } from "@core/types";
 import useLocalStorage from "@hooks/useLocalStorage";
 import { decryptJwt } from "@core/auth";
 import { useNotification } from "./Notification";
+import { useMutation } from "@tanstack/react-query";
 
 const AuthContext = createContext<AuthValue | null>(null);
 
+type AuthResponse = { email: string, token: string };
+
 export function AuthProvider( props: PropsWithChildren ) {
   const [token, setToken, removeToken] = useLocalStorage<string>("token");
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: (credentials: Credentials) => postReq<AuthResponse>("/auth/login", credentials),
+  })
   const user = token ? decryptJwt(token).user : null;
-
-  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const { notify } = useNotification();
 
-  // verify user data with server
   async function loginAction(credentials: Credentials): Promise<void> {
     try {
-      setLoading(true);
-      const response = await client.post("/auth/login", credentials);
-
-      if (response?.status !== 200) {
-        throw new Error("Invalid email or password");
-      }
-
-      setToken(response.data.token);
+      const response = await mutateAsync(credentials);
+      setToken(response.token);
       notify({ message: "You have logged in successfully!", type: "success" });
-
     } catch (err) {
       let message = "";
       if (err instanceof AxiosError) {
@@ -46,8 +42,6 @@ export function AuthProvider( props: PropsWithChildren ) {
         type: "danger"
       });
       navigate("/login", { state: message });
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -64,7 +58,7 @@ export function AuthProvider( props: PropsWithChildren ) {
     }
   }
 
-  return <AuthContext.Provider value={{ user, token, loading, loginAction, logoutAction }}>{props.children}</AuthContext.Provider>
+  return <AuthContext.Provider value={{ user, token, loading: isPending, loginAction, logoutAction }}>{props.children}</AuthContext.Provider>
 }
 
 export default AuthProvider;

--- a/client/src/context/Notification.tsx
+++ b/client/src/context/Notification.tsx
@@ -36,7 +36,7 @@ function NotificationProvider(props: PropsWithChildren) {
             <div className="w-full flex flex-col-reverse gap-2">
                 {notifications.map((item, index) => {
                     return (<TimeLimited key={index} delay={NOTIFICATION_DELAY}>
-                        <Alert color={item.type ?? "default"} description={item.description} title={item.message} variant="faded" />
+                        <Alert color={item.type ?? "default"} description={item.description} title={item.message} className="shadow-xl" />
                     </TimeLimited>
                 )
                 })}

--- a/client/src/core/types.ts
+++ b/client/src/core/types.ts
@@ -42,6 +42,13 @@ export enum UserRole {
   GUEST = "ROLE_GUEST",
 };
 
+export const UserRoleName = {
+  [UserRole.ADMIN]: "Admin",
+  [UserRole.MODERATOR]: "Moderator",
+  [UserRole.CLIENT]: "Client",
+  [UserRole.GUEST]: "Guest"
+}
+
 export enum UserStatus {
   ACTIVE = "Active",
   ON_LEAVE = "On_Leave",

--- a/client/src/core/utils.ts
+++ b/client/src/core/utils.ts
@@ -35,6 +35,10 @@ export function getFullName(user: UserData): string {
     return `${user.name} ${user.surname}`;
 }
 
+export function getInitials(user: UserData): string {
+    return `${user.name.charAt(0).toUpperCase()}${user.surname.charAt(0).toUpperCase()}`;
+}
+
 /**
  * Ensures that the thrown value is indeed an Error. Converts it to Error if it is not.
  */
@@ -185,3 +189,4 @@ export function dayToString(day: number): string {
     }
     return Day[day];
 }
+

--- a/client/src/hooks/useQueryCustomers.tsx
+++ b/client/src/hooks/useQueryCustomers.tsx
@@ -2,8 +2,8 @@ import { UserRole, type UserData } from "@core/types";
 import type { UseQueryResult } from "@tanstack/react-query";
 import useQueryUsersByRole from "./useQueryUsers";
 
-export default function useQueryEmployees(interval?: number): UseQueryResult<(UserData)[] | undefined> {
-  const roles = [UserRole.ADMIN, UserRole.MODERATOR];
+export default function useQueryCustomers(interval?: number): UseQueryResult<(UserData)[] | undefined> {
+  const roles = [UserRole.CLIENT, UserRole.GUEST];
 
   return useQueryUsersByRole(roles, interval);
 }

--- a/client/src/hooks/useQueryUsers.tsx
+++ b/client/src/hooks/useQueryUsers.tsx
@@ -1,0 +1,18 @@
+import type { UserRole } from "@core/types";
+import { type UserData } from "@core/types";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { getReq } from "@core/utils";
+
+const queryKey = "users";
+
+export default function useQueryUsersByRole(roles: UserRole[], interval?: number): UseQueryResult<(UserData)[] | undefined> {
+  const query = useQuery({
+    queryKey: [queryKey, ...roles],
+    queryFn: () => getReq<UserData[]>(queryKey, { params: { "roles": roles.join(",") } }),
+    // stop refetching after encountering error
+    refetchInterval: (query) => query.state.fetchFailureCount > 0 ? false : interval
+  });
+
+  return query;
+}

--- a/client/src/pages/CustomerManagement/CustomerManagement.tsx
+++ b/client/src/pages/CustomerManagement/CustomerManagement.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+import PageHeader from "@components/PageHeader/PageHeader";
+import CustomersTable from "@components/Customers/Table";
+
+export default function ReservationsManagementPage(): ReactElement {
+  return (
+    <>
+      <PageHeader
+        heading="Customers management"
+        subheading="Here you can manage you business customer accounts"
+      />
+      <CustomersTable />
+    </>
+  );
+}

--- a/client/src/pages/Register/Form.tsx
+++ b/client/src/pages/Register/Form.tsx
@@ -156,7 +156,7 @@ export default function RegisterForm() {
           <p className="mb-1 text-xs italic">Permissions</p>
           <div className="flex flex-row flex-wrap mb-2">
             <div className="basis-full p-1">
-              <SelectField name="userRole" label="Role" variant="bordered">
+              <SelectField name="userRole" label="Role" variant="bordered" isRequired>
                 {Object.values(UserRole).map((item: UserRole) => {
                   return (
                     <SelectItem key={item} value={item}>

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/AuthController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.kalyvianakis.estiator.io.controller;
 
 import com.kalyvianakis.estiator.io.dto.LoginRequest;
 import com.kalyvianakis.estiator.io.dto.LoginResponse;
+import com.kalyvianakis.estiator.io.dto.SignupAdminRequest;
 import com.kalyvianakis.estiator.io.dto.SignupRequest;
 import com.kalyvianakis.estiator.io.model.User;
 import com.kalyvianakis.estiator.io.service.AuthService;
@@ -36,6 +37,12 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest requestDto) throws Exception {
         authService.signup(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/signup/admin")
+    public ResponseEntity<Void> signupAdmin(@Valid @RequestBody SignupAdminRequest requestDto) throws Exception {
+        authService.signupAdmin(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/UserController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/UserController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.sql.Time;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,9 +50,9 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<?> get(@PathVariable Long id, @RequestParam(required = false, name = "registered") Boolean registered ) throws ResourceNotFoundException {
-        if (registered != null && registered) {
-            return ResponseEntity.ok().body(userService.getRegistered(id));
+    public ResponseEntity<?> getWithRoles(@PathVariable Long id, @RequestParam(required = false, name = "roles") Collection<String> roles) throws ResourceNotFoundException {
+        if (roles != null && roles.stream().count() > 0) {
+            return ResponseEntity.ok().body(userService.getWithRoles(id, roles));
         }
         return ResponseEntity.ok().body(userService.get(id));
     }
@@ -116,16 +117,11 @@ public class UserController {
         return ResponseEntity.ok().body(schedules);
     }
 
-    @GetMapping()
-    public ResponseEntity<List<User>> get(@RequestParam(required = false, name = "registered") Boolean registered) {
-        if (registered != null) {
-            if (registered) {
-                return ResponseEntity.ok().body(userService.getRegistered());
-            } else {
-                return ResponseEntity.ok().body(userService.getGuest());
-            }
+    @GetMapping
+    public ResponseEntity<List<User>> get(@RequestParam(required = false, name = "roles") Collection<String> roles) {
+        if (roles != null && roles.stream().count() > 0) {
+            return ResponseEntity.ok().body(userService.getByRoles(roles));
         }
-
         return ResponseEntity.ok().body(userService.get());
     }
 

--- a/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupAdminRequest.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupAdminRequest.java
@@ -1,0 +1,16 @@
+package com.kalyvianakis.estiator.io.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class SignupAdminRequest extends SignupRequest {
+    @NotBlank(message = "User role cannot be blank")
+    String userRole;
+
+    public String getUserRole() {
+        return userRole;
+    }
+
+    public void setUserRole(String userRole) {
+        this.userRole = userRole;
+    }
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupRequest.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupRequest.java
@@ -2,7 +2,6 @@ package com.kalyvianakis.estiator.io.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SignupRequest (

--- a/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupRequest.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupRequest.java
@@ -4,19 +4,60 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record SignupRequest (
+public class SignupRequest {
     @NotBlank(message = "Name cannot be blank")
-    String name,
+    String name;
 
     @NotBlank(message = "Surname cannot be blank")
-    String surname,
+    String surname;
 
     @Email(message = "Invalid email format")
     @NotBlank(message = "Email cannot be blank")
-    String email,
+    String email;
 
-    String phone,
+    String phone;
 
     @NotBlank(message = "Password cannot be blank")
     @Size(min = 6, max = 20, message = "Password must be between 6 and 20 characters long")
-    String password) { }
+    String password;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/model/User.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/model/User.java
@@ -27,6 +27,7 @@ public class User extends PropertyPrinter {
     @Column(unique = true)
     private String email;
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
     @Column(unique = true)

--- a/server/src/main/java/com/kalyvianakis/estiator/io/model/User.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/model/User.java
@@ -54,6 +54,16 @@ public class User extends PropertyPrinter {
         this.phone = phone;
         this.password = password;
     }
+
+    public User(String name, String surname, String email, String phone, String password, String userRole) {
+        this.name = name;
+        this.surname = surname;
+        this.email = email;
+        this.phone = phone;
+        this.password = password;
+        this.userRole = userRole;
+    }
+
     public User() {}
 
     @PostLoad

--- a/server/src/main/java/com/kalyvianakis/estiator/io/repository/UserRepository.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/repository/UserRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificationExecutor<User> {
-    List<User> findByUserRoleIn(List<String> userRoles);
+    List<User> findByUserRoleIn(Collection<String> userRoles);
     Optional<User> findByIdAndUserRoleIn(Long id, Collection<String> userRoles);
     Optional<User> findByEmail(String email);
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/AuthService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.kalyvianakis.estiator.io.service;
 
+import com.kalyvianakis.estiator.io.dto.SignupAdminRequest;
 import com.kalyvianakis.estiator.io.dto.SignupRequest;
 import com.kalyvianakis.estiator.io.model.User;
 import com.kalyvianakis.estiator.io.repository.UserRepository;
@@ -21,17 +22,30 @@ public class AuthService {
 
     @Transactional
     public void signup(SignupRequest request) throws Exception {
-        String email = request.email();
+        String email = request.getEmail();
         Optional<User> existingUser = userRepository.findByEmail(email);
         if (existingUser.isPresent()) {
             throw new DuplicateResourceException(String.format("User with the email address '%s' already exists", email));
         }
 
-        String hashedPassword = passwordEncoder.encode(request.password());
-        User user = new User(request.name(), request.surname(), email, request.phone(), hashedPassword);
+        String hashedPassword = passwordEncoder.encode(request.getPassword());
+        User user = new User(request.getName(), request.getSurname(), email, request.getPhone(), hashedPassword);
 
         // set default user role for each new user
         user.setUserRole("ROLE_CLIENT");
+
+        userRepository.save(user);
+    }
+
+    public void signupAdmin(SignupAdminRequest request) throws Exception {
+        String email = request.getEmail();
+        Optional<User> existingUser = userRepository.findByEmail(email);
+        if (existingUser.isPresent()) {
+            throw new DuplicateResourceException(String.format("User with the email address '%s' already exists", email));
+        }
+
+        String hashedPassword = passwordEncoder.encode(request.getPassword());
+        User user = new User(request.getName(), request.getSurname(), email, request.getPhone(), hashedPassword, request.getUserRole());
 
         userRepository.save(user);
     }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/AuthService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/AuthService.java
@@ -29,6 +29,10 @@ public class AuthService {
 
         String hashedPassword = passwordEncoder.encode(request.password());
         User user = new User(request.name(), request.surname(), email, request.phone(), hashedPassword);
+
+        // set default user role for each new user
+        user.setUserRole("ROLE_CLIENT");
+
         userRepository.save(user);
     }
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/IUserService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/IUserService.java
@@ -10,7 +10,6 @@ public interface IUserService {
     public List<User> get();
     public User get(Long id) throws ResourceNotFoundException;
     public User getOneByEmail(String email) throws ResourceNotFoundException;
-    public List<User> getRegistered();
     public void delete(Long id);
     public Boolean exists(Long id);
     public Boolean notExists(Long id);

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/UserService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/UserService.java
@@ -48,27 +48,12 @@ public class UserService implements IUserService, UserDetailsService {
         return userRepository.findByEmail(email).orElseThrow(() -> new ResourceNotFoundException("User not found with Email: " + email));
     }
 
-    public User getRegistered(Long id) throws ResourceNotFoundException {
-        List<String> roleValues = new ArrayList<>();
-        roleValues.add("ROLE_MODERATOR");
-        roleValues.add("ROLE_ADMIN");
-        return userRepository.findByIdAndUserRoleIn(id, roleValues).orElseThrow(() -> new ResourceNotFoundException("Registered user not found with ID: " + id));
+    public User getWithRoles(Long id, Collection<String> roles) throws ResourceNotFoundException {
+        return userRepository.findByIdAndUserRoleIn(id, roles).orElseThrow(() -> new ResourceNotFoundException("Registered user not found with ID: " + id));
     }
 
-    public List<User> getRegistered() {
-        return this.getByRoles("ROLE_ADMIN", "ROLE_MODERATOR");
-    }
-
-    public List<User> getGuest() {
-        return this.getByRoles("ROLE_GUEST");
-    }
-
-    public List<User> getClient() {
-        return this.getByRoles("ROLE_CLIENT");
-    }
-
-    public List<User> getByRoles(String ...roles){
-        return userRepository.findByUserRoleIn(Arrays.asList(roles));
+    public List<User> getByRoles(Collection<String> roles){
+        return userRepository.findByUserRoleIn(roles);
     }
 
     public List<Schedule> getSchedule(Long id) {

--- a/server/src/main/java/com/kalyvianakis/estiator/io/utils/JwtAuthFilter.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/utils/JwtAuthFilter.java
@@ -1,6 +1,5 @@
 package com.kalyvianakis.estiator.io.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kalyvianakis.estiator.io.model.ErrorResponse;
 import com.kalyvianakis.estiator.io.service.UserService;
 import io.jsonwebtoken.JwtException;
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {

--- a/server/src/main/java/com/kalyvianakis/estiator/io/utils/config/SecurityConfig.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/utils/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/signup/admin/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers(HttpMethod.POST, "/auth/signup/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/login/**").permitAll()
 
@@ -56,9 +57,11 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/tables/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_MODERATOR")
                         .requestMatchers(HttpMethod.PATCH, "/tables/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_MODERATOR")
 
-                        .requestMatchers("/users/**").hasAnyAuthority("ROLE_ADMIN")
+                        .requestMatchers(HttpMethod.GET ,"/users/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_MODERATOR")
+                        .requestMatchers(HttpMethod.PATCH ,"/users/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_MODERATOR")
+                        .requestMatchers("/users/**").hasAuthority("ROLE_ADMIN")
 
-                        .requestMatchers("/schedules/**").hasAnyAuthority("ROLE_ADMIN")
+                        .requestMatchers("/schedules/**").hasAuthority("ROLE_ADMIN")
 
                         .requestMatchers(HttpMethod.DELETE).hasAuthority("ROLE_ADMIN")
                         .anyRequest().hasAuthority("ROLE_ADMIN"))


### PR DESCRIPTION
## Description 

In this PR the goal is the implementation of a page exclusively for the management of users with either `CLIENT` or `GUEST` roles. `CLIENT` users are users that are registered in the application with their credentials, while `GUEST` users are users for which the application has limited information about (e.g. no password set). 

The Customer Management page is accessible only to `ADMIN` users and as of now they can only `delete` and `edit` an existing customer, but not create one. Customers can only be created (for now) via the registration page. Any user that is registered through that page will immediatelly receive the `CLIENT` role. 

## Known issues 

- Changing the password is currently not available.
- `GUEST` role is currently not used in the way that it should.

## Additional information 

#### Some improvements include : 
- (server) Reworked on functions that fetch users by their role 
- (server) Added `ROLE_CLIENT` for all newly created users 
- (client) Implemented `useQueryUserByRoles` to allow fetching and caching or users data by given roles

## Screenshots

**Customers Page**  
![image](https://github.com/user-attachments/assets/08c06c9d-53ee-47c5-8272-75d5b02f09b9)

**Actions menu**
![image](https://github.com/user-attachments/assets/1d71013f-963d-4d47-aec4-95dbce040a6c)

**Edit customer modal**
![image](https://github.com/user-attachments/assets/51c04e46-7227-4c7a-857e-b9f6bf283263)


****