### PR TITLE
Fix reservations API and persistence of users related

### DIFF
--- a/client/src/components/Modal/CreateReservation.tsx
+++ b/client/src/components/Modal/CreateReservation.tsx
@@ -40,8 +40,10 @@ export default function CreateReservationModal(props: Props) {
     const data = {
       date: values.date.toString(),
       persons: values.persons,
-      createdBy: { id: user ? user.id : null },
-      createdFor: { id: user ? user.id : null },
+      email: values.email,
+      name: values.name,
+      phone: values.phone,
+      surname: values.surname,
       ...(values.table && { table: { id: Number(values.table) } }),
       time: parseTime(values.time).toString(),
       status: 0,

--- a/client/src/components/Modal/CreateReservation.tsx
+++ b/client/src/components/Modal/CreateReservation.tsx
@@ -10,7 +10,6 @@ import EmailField from "@components/Fields/Email";
 import TimeField from "@components/Fields/Time";
 import { parseTime, today } from "@internationalized/date";
 import TablesSelect from "../Fields/Tables";
-import { useAuth } from "@context/Authentication";
 import { useMutation } from "@tanstack/react-query";
 import { postReq } from "@core/utils";
 import { useNotification } from "@context/Notification";
@@ -20,8 +19,6 @@ type Props = ReturnType<typeof useDisclosure>;
 export default function CreateReservationModal(props: Props) {
   const { isOpen, onOpenChange, onClose } = props;
   const { notify } = useNotification();
-  const auth = useAuth();
-  const user = auth?.user;
   const { mutateAsync, isPending } = useMutation({
     mutationFn: (data: unknown) => postReq("reservations", data),
     onSuccess: () => notify({ message: "Reservations has been created successfully!", type: "success" }),

--- a/client/src/components/Modal/EditReservation.tsx
+++ b/client/src/components/Modal/EditReservation.tsx
@@ -31,10 +31,6 @@ export default function EditReservationModal(props: Props) {
     defaultValues: {
       date: parseDate(reservation.date),
       time: toParsedTimeString(reservation.time),
-      name: reservation.createdBy.name,
-      surname: reservation.createdBy.surname,
-      email: reservation.createdBy.email,
-      phone: reservation.createdBy.phone,
       persons: reservation.persons.toString(),
       table: String(reservation?.table?.id),
       status: reservation.status,
@@ -48,12 +44,6 @@ export default function EditReservationModal(props: Props) {
       const data = {
         date: values.date.toString(),
         persons: values.persons,
-        user: {
-          name: values.name,
-          surname: values.surname,
-          email: values.email,
-          phone: values.phone
-        },
         table: { id: values.table != "" ? Number(values.table) : null },
         time: parseTime(values.time).toString(),
         status: values.status,
@@ -95,10 +85,10 @@ export default function EditReservationModal(props: Props) {
                 <div className="w-full md:w-3/4 md:flex-grow flex flex-col gap-2">
                   <NumberField isRequired label="Persons" name="persons" />
                   <TablesSelect label="Select table" name="table" />
-                  <InputField isRequired label="Name" name="name"  />
-                  <InputField isRequired label="Surname" name="surname" />
-                  <EmailField isRequired label="Email" name="email" />
-                  <InputField label="Phone" name="phone" />
+                  <InputField isReadOnly isDisabled label="Name" name="name"  />
+                  <InputField isReadOnly isDisabled label="Surname" name="surname" />
+                  <EmailField isReadOnly isDisabled label="Email" name="email" />
+                  <InputField isReadOnly isDisabled label="Phone" name="phone" />
                 </div>
               </div>
               <ReservationStatusField name="status" label="Status">

--- a/client/src/components/Reservations/Table.tsx
+++ b/client/src/components/Reservations/Table.tsx
@@ -74,8 +74,8 @@ export default function ReservationsTable() {
             classNames={{
               description: "text-default-500",
             }}
-            description={reservation.createdBy.email || reservation.createdBy.phone}
-            name={getFullName(reservation.createdBy)}
+            description={reservation.createdFor?.email || reservation.createdFor?.phone}
+            name={getFullName(reservation.createdFor)}
           />
         </TableCell>
         <TableCell className="w-[20%]" textValue="Date">

--- a/client/src/components/UserMenu/UserMenu.tsx
+++ b/client/src/components/UserMenu/UserMenu.tsx
@@ -1,7 +1,7 @@
 import { Dropdown, DropdownItem, DropdownMenu } from "@heroui/react";
 import type { ReactElement } from "react";
 import { useAuth } from "@context/Authentication";
-import { UserRoleName, type UserData } from "@core/types";
+import { UserRole, UserRoleName, type UserData } from "@core/types";
 import UserAvatar from "@components/Avatar/User";
 
 type Props = {
@@ -22,7 +22,7 @@ export default function UserMenu(props: Props): ReactElement {
         <DropdownMenu aria-label="User Actions" variant="flat">
           <DropdownItem key="profile" className="h-14 gap-2">
             <p className="font-bold">Signed in as</p>
-            <p>{UserRoleName?.[auth?.user?.userRole || "ROLE_UNKNOWN"]}</p>
+            <p>{UserRoleName?.[auth?.user?.userRole || UserRole.UNKNOWN]}</p>
           </DropdownItem>
           <DropdownItem onPress={handleLogout} key="logout" color="danger">
             Log Out

--- a/client/src/components/UserMenu/UserMenu.tsx
+++ b/client/src/components/UserMenu/UserMenu.tsx
@@ -1,7 +1,7 @@
 import { Dropdown, DropdownItem, DropdownMenu } from "@heroui/react";
 import type { ReactElement } from "react";
 import { useAuth } from "@context/Authentication";
-import type { UserData } from "@core/types";
+import { UserRoleName, type UserData } from "@core/types";
 import UserAvatar from "@components/Avatar/User";
 
 type Props = {
@@ -22,7 +22,7 @@ export default function UserMenu(props: Props): ReactElement {
         <DropdownMenu aria-label="User Actions" variant="flat">
           <DropdownItem key="profile" className="h-14 gap-2">
             <p className="font-bold">Signed in as</p>
-            <p className="font-bold">Administrator</p>
+            <p>{UserRoleName?.[auth?.user?.userRole || "ROLE_UNKNOWN"]}</p>
           </DropdownItem>
           <DropdownItem onPress={handleLogout} key="logout" color="danger">
             Log Out

--- a/client/src/core/types.ts
+++ b/client/src/core/types.ts
@@ -46,7 +46,8 @@ export const UserRoleName = {
   [UserRole.ADMIN]: "Admin",
   [UserRole.MODERATOR]: "Moderator",
   [UserRole.CLIENT]: "Client",
-  [UserRole.GUEST]: "Guest"
+  [UserRole.GUEST]: "Guest",
+  "ROLE_UNKNOWN": "Unknown role"
 }
 
 export enum UserStatus {

--- a/client/src/core/types.ts
+++ b/client/src/core/types.ts
@@ -40,6 +40,7 @@ export enum UserRole {
   MODERATOR = "ROLE_MODERATOR",
   CLIENT = "ROLE_CLIENT",
   GUEST = "ROLE_GUEST",
+  UNKNOWN = "ROLE_UNKNOWN"
 };
 
 export const UserRoleName = {
@@ -47,7 +48,7 @@ export const UserRoleName = {
   [UserRole.MODERATOR]: "Moderator",
   [UserRole.CLIENT]: "Client",
   [UserRole.GUEST]: "Guest",
-  "ROLE_UNKNOWN": "Unknown role"
+  [UserRole.UNKNOWN]: "Unknown"
 }
 
 export enum UserStatus {

--- a/server/src/main/java/com/kalyvianakis/estiator/io/dto/ReservationRequest.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/dto/ReservationRequest.java
@@ -1,0 +1,110 @@
+package com.kalyvianakis.estiator.io.dto;
+
+import com.kalyvianakis.estiator.io.enums.ReservationStatus;
+import com.kalyvianakis.estiator.io.model.Table;
+import com.kalyvianakis.estiator.io.model.User;
+
+import java.sql.Time;
+import java.sql.Date;
+
+public class ReservationRequest {
+    private Date date;
+
+    private Time time;
+
+    private Integer persons;
+
+    private Table table;
+
+    private User createdBy;
+
+    private String email;
+
+    private String name;
+
+    private String surname;
+
+    private String phone;
+
+    private ReservationStatus status;
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public Time getTime() {
+        return time;
+    }
+
+    public void setTime(Time time) {
+        this.time = time;
+    }
+
+    public Integer getPersons() {
+        return persons;
+    }
+
+    public void setPersons(Integer persons) {
+        this.persons = persons;
+    }
+
+    public Table getTable() {
+        return table;
+    }
+
+    public void setTable(Table table) {
+        this.table = table;
+    }
+
+    public User getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(User createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public ReservationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ReservationStatus status) {
+        this.status = status;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupAdminRequest.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupAdminRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public class SignupAdminRequest extends SignupRequest {
     @NotBlank(message = "User role cannot be blank")
-    String userRole;
+    private String userRole;
 
     public String getUserRole() {
         return userRole;

--- a/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupRequest.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/dto/SignupRequest.java
@@ -6,20 +6,20 @@ import jakarta.validation.constraints.Size;
 
 public class SignupRequest {
     @NotBlank(message = "Name cannot be blank")
-    String name;
+    private String name;
 
     @NotBlank(message = "Surname cannot be blank")
-    String surname;
+    private String surname;
 
     @Email(message = "Invalid email format")
     @NotBlank(message = "Email cannot be blank")
-    String email;
+    private String email;
 
-    String phone;
+    private String phone;
 
     @NotBlank(message = "Password cannot be blank")
     @Size(min = 6, max = 20, message = "Password must be between 6 and 20 characters long")
-    String password;
+    private String password;
 
     public String getName() {
         return name;

--- a/server/src/main/java/com/kalyvianakis/estiator/io/model/Reservation.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/model/Reservation.java
@@ -42,16 +42,28 @@ public class Reservation extends PropertyPrinter {
   private Timestamp createdDate;
 
   @ManyToOne
-  @JoinColumn(name = "created_by_user_id", referencedColumnName = "id", nullable = true)
+  @JoinColumn(name = "created_by_user_id", referencedColumnName = "id")
   @JsonIgnoreProperties(value = { "tables", "reservations", "createdReservations", "referredReservations" })
   @JsonProperty(value = "createdBy")
   private User createdBy;
 
   @ManyToOne
-  @JoinColumn(name = "created_for_user_id", referencedColumnName = "id", nullable = true)
+  @JoinColumn(name = "created_for_user_id", referencedColumnName = "id")
   @JsonIgnoreProperties(value = { "tables", "reservations", "createdReservations", "referredReservations" })
   @JsonProperty(value = "createdFor")
   private User createdFor;
+
+
+  public Reservation(Date date, Time time, ReservationStatus status, Table table, User createdBy, User createdFor) {
+    this.date = date;
+    this.time = time;
+    this.status = status;
+    this.table = table;
+    this.createdBy = createdBy;
+    this.createdFor = createdFor;
+  }
+
+  public Reservation() {}
 
   @PostLoad
   @SuppressWarnings("unused")

--- a/server/src/main/java/com/kalyvianakis/estiator/io/model/User.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/model/User.java
@@ -47,25 +47,6 @@ public class User extends PropertyPrinter {
     @JsonIgnore
     private Short statusValue;
 
-    public User(String name, String surname, String email, String phone, String password) {
-        this.name = name;
-        this.surname = surname;
-        this.email = email;
-        this.phone = phone;
-        this.password = password;
-    }
-
-    public User(String name, String surname, String email, String phone, String password, String userRole) {
-        this.name = name;
-        this.surname = surname;
-        this.email = email;
-        this.phone = phone;
-        this.password = password;
-        this.userRole = userRole;
-    }
-
-    public User() {}
-
     @PostLoad
     @SuppressWarnings("unused")
     void fillTransientStatus() {
@@ -89,11 +70,11 @@ public class User extends PropertyPrinter {
     @JsonIgnoreProperties(value = { "user" })
     private List<Table> tables;
 
-    @OneToMany(mappedBy = "createdBy", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "createdBy", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonIgnoreProperties(value = { "table", "user" })
     private List<Reservation> createdReservations;
 
-    @OneToMany(mappedBy = "createdFor", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "createdFor", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonIgnoreProperties(value = { "table", "user" })
     private List<Reservation> referredReservations;
 
@@ -101,6 +82,25 @@ public class User extends PropertyPrinter {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.PERSIST)
     @JsonIgnoreProperties(value = { "user" })
     private List<Schedule> schedules;
+
+    public User(String name, String surname, String email, String phone, String password) {
+        this.name = name;
+        this.surname = surname;
+        this.email = email;
+        this.phone = phone;
+        this.password = password;
+    }
+
+    public User(String name, String surname, String email, String phone, String password, String userRole) {
+        this.name = name;
+        this.surname = surname;
+        this.email = email;
+        this.phone = phone;
+        this.password = password;
+        this.userRole = userRole;
+    }
+
+    public User() {}
 
     private Long getId() {
         return id;

--- a/server/src/main/java/com/kalyvianakis/estiator/io/repository/UserRepository.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/repository/UserRepository.java
@@ -14,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
     List<User> findByUserRoleIn(Collection<String> userRoles);
     Optional<User> findByIdAndUserRoleIn(Long id, Collection<String> userRoles);
     Optional<User> findByEmail(String email);
+    Boolean existsByEmail(String email);
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/IUserService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/IUserService.java
@@ -6,11 +6,12 @@ import com.kalyvianakis.estiator.io.model.User;
 import java.util.List;
 
 public interface IUserService {
-    public User save(User user);
-    public List<User> get();
-    public User get(Long id) throws ResourceNotFoundException;
-    public User getOneByEmail(String email) throws ResourceNotFoundException;
-    public void delete(Long id);
-    public Boolean exists(Long id);
-    public Boolean notExists(Long id);
+    User save(User user);
+    User saveAndFlush(User user);
+    List<User> get();
+    User get(Long id) throws ResourceNotFoundException;
+    User getOneByEmail(String email) throws ResourceNotFoundException;
+    void delete(Long id);
+    Boolean exists(Long id);
+    Boolean notExists(Long id);
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/UserService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/UserService.java
@@ -31,6 +31,9 @@ public class UserService implements IUserService, UserDetailsService {
     }
 
     @Override
+    public User saveAndFlush(User user) { return userRepository.saveAndFlush(user); }
+
+    @Override
     public List<User> get() {
         return userRepository.findAll();
     }
@@ -46,6 +49,13 @@ public class UserService implements IUserService, UserDetailsService {
             throw new IllegalArgumentException("Email must not be null");
         }
         return userRepository.findByEmail(email).orElseThrow(() -> new ResourceNotFoundException("User not found with Email: " + email));
+    }
+
+    public boolean existsByEmail(String email) throws IllegalArgumentException {
+        if (email == null) {
+            throw new IllegalArgumentException("Email must not be null");
+        }
+        return userRepository.existsByEmail(email);
     }
 
     public User getWithRoles(Long id, Collection<String> roles) throws ResourceNotFoundException {


### PR DESCRIPTION
## Description 

This PR is related to fixing some issues in Reservations and more specifically the functionality related to assigning users on the creation of a reservation.

What has been changed: 
- The `createdBy` parameter (meaning the user that is creating the reservation) is not send via the POST request to the backend, but is rather obtained by the `token` that the user is sending for his authentication and authorization in the app, through `Authorization` HTTP headers.

 - The `createdFor` user (meaning the user for whom the reservation is created) is populated in two ways when the application user creates a reservations. (1) either by getting the email in the request, finding an existing user and using that user for the `createdFor` or (2) when not finding an existing user and just creating a guest using the request data of the reservation (name, surname, email and phone). 
 
- The `EditReservation` form is also affected by the changes. In that form, the user **cannot** edit the details of the user that the reservation belongs to (`createdFor`). These details are currently read-only. So, the user will be required to create a new reservation for reservations that have incorrect user details.


## Additional info

When sending the `CreateReservation` form, the following case can occur: 
  - The user has set a `name`, `surname` and `phone`, even though there is an existing user with the provided `email`

In the above scenario, the server is handling the request in a completely silent way. The existing user is associated with the created reservation and the `name`, `surname` and `phone` that the user provided are ignored.



 