### PR TITLE
Implement dashboard minicard widgets

### DIFF
--- a/client/src/components/Minicard/Minicard.tsx
+++ b/client/src/components/Minicard/Minicard.tsx
@@ -1,0 +1,28 @@
+import { Card, CardBody } from "@heroui/react";
+import type { ReactNode } from "react";
+
+type Props = {
+    headline?: string | number;
+    icon?: ReactNode,
+    description?: string | number | undefined;
+    indicator?: ReactNode;
+}
+
+export default function Minicard(props: Props) {
+    return (
+        <Card className="py-2 px-4 w-[280px] shrink-0" shadow="sm">
+            <CardBody>
+                <div className="mb-1 flex flex-row flex-nowrap justify-between items-center">
+                    <h4 className="text-sm opacity-30 font-semibold">{props.headline ?? "-"}</h4>
+                    <div className="rounded-full text-cyan-600 bg-slate-100 p-2 border-1 border-cyan-600 border-opacity-20">
+                        {props.icon}
+                    </div>
+                </div>
+                <div className="flex flex-row gap-1 flex-nowrap justify-start items-end">
+                    <p className="text-3xl font-bold">{props.description ?? "-"}</p>
+                    {props.indicator}
+                </div>
+            </CardBody>
+        </Card>
+    )
+}

--- a/client/src/components/Minicard/Minicard.tsx
+++ b/client/src/components/Minicard/Minicard.tsx
@@ -13,7 +13,7 @@ export default function Minicard(props: Props) {
         <Card className="py-2 px-4 w-[280px] shrink-0" shadow="sm">
             <CardBody>
                 <div className="mb-1 flex flex-row flex-nowrap justify-between items-center">
-                    <h4 className="text-sm opacity-30 font-semibold">{props.headline ?? "-"}</h4>
+                    <h4 className="text-sm text-foreground-500 font-semibold">{props.headline ?? "-"}</h4>
                     <div className="rounded-full text-cyan-600 bg-slate-100 p-2 border-1 border-cyan-600 border-opacity-20">
                         {props.icon}
                     </div>

--- a/client/src/components/Minicard/MonthReservations.tsx
+++ b/client/src/components/Minicard/MonthReservations.tsx
@@ -13,8 +13,8 @@ export default function MonthReservations() {
     const prevMonthEnd = endOfMonth(t.subtract({ months: 1 }))
     const prevMonthStart = startOfMonth(t.subtract({ months: 1 }))
 
-    const { data: currentReservations } = useQueryReservations<number>(3000, { params: { count: true, dateFrom: currMonthStart, dateTo: currMonthEnd.toString() } });
-    const { data: lastMonthReservations } = useQueryReservations<number>(3000, { params: { count: true, dateFrom: prevMonthStart, dateTo: prevMonthEnd.toString() } });
+    const { data: currentReservations } = useQueryReservations<number>(3000, { count: true, dateFrom: currMonthStart.toString(), dateTo: currMonthEnd.toString() });
+    const { data: lastMonthReservations } = useQueryReservations<number>(3000, { count: true, dateFrom: prevMonthStart.toString(), dateTo: prevMonthEnd.toString() });
 
     const change = useMemo(() => {
         if (!isUndefined(currentReservations) && isInteger(currentReservations) && !isUndefined(lastMonthReservations) && isInteger(lastMonthReservations)) {

--- a/client/src/components/Minicard/MonthReservations.tsx
+++ b/client/src/components/Minicard/MonthReservations.tsx
@@ -1,17 +1,20 @@
 import useQueryReservations from "@hooks/useQueryReservations"
 import Minicard from "./Minicard";
 import TableClockIcon from "@components/Icons/TableClockIcon";
-import { endOfMonth, today } from "@internationalized/date";
+import { endOfMonth, startOfMonth, today } from "@internationalized/date";
 import { useMemo } from "react";
 import { isInteger, isUndefined } from "@core/utils";
 import { Tooltip } from "@heroui/react";
 
-export default function TotalReservations() {
-    const currentMonth = endOfMonth(today("Europe/Athens"));
-    const previousMonth = currentMonth.subtract({ months: 1 });
+export default function MonthReservations() {
+    const t = today("Europe/Athens");
+    const currMonthEnd = endOfMonth(t);
+    const currMonthStart = startOfMonth(t);
+    const prevMonthEnd = endOfMonth(t.subtract({ months: 1 }))
+    const prevMonthStart = startOfMonth(t.subtract({ months: 1 }))
 
-    const { data: currentReservations } = useQueryReservations<number>(3000, { params: { count: true, date: currentMonth.toString() } });
-    const { data: lastMonthReservations } = useQueryReservations<number>(3000, { params: { count: true, date: previousMonth.toString() } });
+    const { data: currentReservations } = useQueryReservations<number>(3000, { params: { count: true, dateFrom: currMonthStart, dateTo: currMonthEnd.toString() } });
+    const { data: lastMonthReservations } = useQueryReservations<number>(3000, { params: { count: true, dateFrom: prevMonthStart, dateTo: prevMonthEnd.toString() } });
 
     const change = useMemo(() => {
         if (!isUndefined(currentReservations) && isInteger(currentReservations) && !isUndefined(lastMonthReservations) && isInteger(lastMonthReservations)) {
@@ -28,7 +31,7 @@ export default function TotalReservations() {
         description={currentReservations}
         headline="Month Reservations"
         indicator={<div className="relative">
-            <Tooltip content="Compared to last month" closeDelay={0} placement="right" className="cursor-pointer" showArrow>
+            <Tooltip content="Increase compared to last month" closeDelay={0} placement="right" className="cursor-pointer" showArrow>
                 <p className={`${indicatorClass} text-xs cursor-default`}>{indicatorPrepend}{change}%</p>
             </Tooltip>
         </div>}

--- a/client/src/components/Minicard/MonthReservations.tsx
+++ b/client/src/components/Minicard/MonthReservations.tsx
@@ -1,0 +1,37 @@
+import useQueryReservations from "@hooks/useQueryReservations"
+import Minicard from "./Minicard";
+import TableClockIcon from "@components/Icons/TableClockIcon";
+import { endOfMonth, today } from "@internationalized/date";
+import { useMemo } from "react";
+import { isInteger, isUndefined } from "@core/utils";
+import { Tooltip } from "@heroui/react";
+
+export default function MonthReservations() {
+    const currentMonth = endOfMonth(today("Europe/Athens"));
+    const previousMonth = currentMonth.subtract({ months: 1 });
+
+    const { data: currentReservations } = useQueryReservations<number>(3000, { params: { count: true, date: currentMonth.toString() } });
+    const { data: lastMonthReservations } = useQueryReservations<number>(3000, { params: { count: true, date: previousMonth.toString() } });
+
+    const change = useMemo(() => {
+        if (!isUndefined(currentReservations) && isInteger(currentReservations) && !isUndefined(lastMonthReservations) && isInteger(lastMonthReservations)) {
+            const diff = currentReservations - lastMonthReservations;
+            const percentage = (diff / currentReservations) * 100;
+            return Number(percentage.toFixed(1));
+        }
+    }, [currentReservations, lastMonthReservations]);
+
+    const indicatorClass = isUndefined(change) || change === 0 ? "text-warning" : change > 0 ? "text-success" : "text-danger";
+    const indicatorPrepend = isUndefined(change) ? "" : change === 0 ? "~" : change > 0 ? "+" : "";
+
+    return <Minicard
+        description={currentReservations}
+        headline="Month Reservations"
+        indicator={<div className="relative">
+            <Tooltip content="Compared to last month" closeDelay={0} placement="right" className="cursor-pointer" showArrow>
+                <p className={`${indicatorClass} text-xs cursor-default`}>{indicatorPrepend}{change}%</p>
+            </Tooltip>
+        </div>}
+        icon={<TableClockIcon />}
+    />;
+}

--- a/client/src/components/Minicard/MonthReservations.tsx
+++ b/client/src/components/Minicard/MonthReservations.tsx
@@ -24,8 +24,8 @@ export default function MonthReservations() {
         }
     }, [currentReservations, lastMonthReservations]);
 
-    const indicatorClass = isUndefined(change) || change === 0 ? "text-warning" : change > 0 ? "text-success" : "text-danger";
-    const indicatorPrepend = isUndefined(change) ? "" : change === 0 ? "~" : change > 0 ? "+" : "";
+    const indicatorClass = !change ? "text-warning" : change > 0 ? "text-success" : "text-danger";
+    const indicatorPrepend = !change ? "-" : change === 0 ? "~" : change > 0 ? "+" : "";
 
     return <Minicard
         description={currentReservations}

--- a/client/src/components/Minicard/TotalCapacity.tsx
+++ b/client/src/components/Minicard/TotalCapacity.tsx
@@ -3,10 +3,10 @@ import TableIcon from "@components/Icons/TableIcon";
 import useQueryTables from "@hooks/useQueryTables";
 
 export default function TotalCapacity() {
-    const { data: tablesCount } = useQueryTables<number>(3000, { params: { capacity: true } });
+    const { data: tablesCount } = useQueryTables<number>(3000, { capacity: true });
 
     return <Minicard
-        headline="Total Capacity"
+        headline="Max occupancy"
         description={tablesCount}
         icon={<TableIcon />}
         indicator={<p className="text-xs text-foreground-400">persons</p>}

--- a/client/src/components/Minicard/TotalCapacity.tsx
+++ b/client/src/components/Minicard/TotalCapacity.tsx
@@ -9,5 +9,6 @@ export default function TotalCapacity() {
         headline="Total Capacity"
         description={tablesCount}
         icon={<TableIcon />}
+        indicator={<p className="text-xs text-foreground-400">persons</p>}
     />;
 }

--- a/client/src/components/Minicard/TotalCapacity.tsx
+++ b/client/src/components/Minicard/TotalCapacity.tsx
@@ -1,0 +1,13 @@
+import Minicard from "./Minicard";
+import TableIcon from "@components/Icons/TableIcon";
+import useQueryTables from "@hooks/useQueryTables";
+
+export default function TotalCapacity() {
+    const { data: tablesCount } = useQueryTables<number>(3000, { params: { capacity: true } });
+
+    return <Minicard
+        headline="Total Capacity"
+        description={tablesCount}
+        icon={<TableIcon />}
+    />;
+}

--- a/client/src/components/Minicard/TotalReservations.tsx
+++ b/client/src/components/Minicard/TotalReservations.tsx
@@ -6,7 +6,7 @@ import { useMemo } from "react";
 import { isInteger, isUndefined } from "@core/utils";
 import { Tooltip } from "@heroui/react";
 
-export default function MonthReservations() {
+export default function TotalReservations() {
     const currentMonth = endOfMonth(today("Europe/Athens"));
     const previousMonth = currentMonth.subtract({ months: 1 });
 

--- a/client/src/components/Minicard/TotalTables.tsx
+++ b/client/src/components/Minicard/TotalTables.tsx
@@ -1,0 +1,14 @@
+import Minicard from "./Minicard";
+import TableIcon from "@components/Icons/TableIcon";
+import useQueryTables from "@hooks/useQueryTables";
+
+export default function TotalTables() {
+    const { data: count } = useQueryTables<number>(3000, { count: true } );
+
+    return <Minicard
+        headline="Total Tables"
+        description={count}
+        icon={<TableIcon />}
+        indicator={<p className="text-xs text-foreground-400">tables</p>}
+    />;
+}

--- a/client/src/components/PageHeader/PageHeader.tsx
+++ b/client/src/components/PageHeader/PageHeader.tsx
@@ -9,7 +9,7 @@ export default function PageHeader(props: Props): ReactElement {
   const { heading, subheading } = props;
 
   return (
-    <div className="mb-5">
+    <div className="mb-5 bg-content1 p-3 rounded-lg">
       <h1 className="text-lg tracking-wide drop-shadow-md mb-0">{heading}</h1>
       {subheading && <p className="mt-0 text-xs text-slate-400">{subheading}</p>}
     </div>

--- a/client/src/components/PageHeader/PageHeader.tsx
+++ b/client/src/components/PageHeader/PageHeader.tsx
@@ -10,7 +10,7 @@ export default function PageHeader(props: Props): ReactElement {
 
   return (
     <div className="mb-5">
-      <h1 className="text-3xl tracking-wide drop-shadow-md font-light mb-0">{heading}</h1>
+      <h1 className="text-lg tracking-wide drop-shadow-md mb-0">{heading}</h1>
       {subheading && <p className="mt-0 text-xs text-slate-400">{subheading}</p>}
     </div>
   );

--- a/client/src/components/Widget/Reservation.tsx
+++ b/client/src/components/Widget/Reservation.tsx
@@ -74,7 +74,7 @@ export default function ReservationWidget() {
   }
 
   return (
-    <Card className="py-4">
+    <Card className="py-2" shadow="sm">
       <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
         <p className="text-tiny uppercase font-bold">status</p>
         <small className="text-default-500"></small>
@@ -83,6 +83,7 @@ export default function ReservationWidget() {
       <CardBody className="overflow-visible py-2">
         <Table
           hideHeader={false}
+          removeWrapper
           isStriped
           {...filtered && { bottomContent: <small><Link className="text-primary" to={"reservations-management"}>View all reservations</Link></small> }}
         >

--- a/client/src/components/Widget/Reservation.tsx
+++ b/client/src/components/Widget/Reservation.tsx
@@ -77,10 +77,9 @@ export default function ReservationWidget() {
       </CardHeader>
       <CardBody className="overflow-visible py-2">
         <Table
-          hideHeader={false}
           removeWrapper
           isStriped
-          {...filtered && { bottomContent: <small><Link className="text-primary" to={"reservations-management"}>View all reservations</Link></small> }}
+          {...filtered && { bottomContent: <small><Link className="text-primary px-1" to={"reservations-management"}>View all reservations</Link></small> }}
         >
           <TableHeader>
             <TableColumn>Name</TableColumn>

--- a/client/src/components/Widget/Reservation.tsx
+++ b/client/src/components/Widget/Reservation.tsx
@@ -2,7 +2,7 @@ import IconButton from "@components/IconButton/IconButton";
 import TickIcon from "@components/Icons/TickIcon";
 import type { ReservationData } from "@core/types";
 import { ReservationStatus } from "@core/types";
-import { getFullName, patchReq, sortByTimeAscending } from "@core/utils";
+import toParsedTimeString, { getFullName, patchReq, sortByTimeAscending } from "@core/utils";
 import useQueryReservations from "@hooks/useQueryReservations";
 import { getLocalTimeZone, isToday, parseDate } from "@internationalized/date";
 import { Card, CardBody, CardHeader, Spinner, Table, TableBody, TableCell, TableColumn, TableHeader, TableRow } from "@heroui/react";
@@ -43,11 +43,8 @@ export default function ReservationWidget() {
         <TableCell className="w-[35%]" textValue="Name">
           {getFullName(reservation.createdFor)}
         </TableCell>
-        <TableCell className="w-[30%]" textValue="Date">
-          {reservation.date}
-        </TableCell>
         <TableCell className="w-[25%]" textValue="Time">
-          {reservation.time}
+          {toParsedTimeString(reservation.time)}
         </TableCell>
         <TableCell className="w-[10%]" textValue="Table">
           {reservation?.table?.label ?? "-"}
@@ -76,9 +73,7 @@ export default function ReservationWidget() {
   return (
     <Card className="py-2" shadow="sm">
       <CardHeader className="pb-0 pt-2 px-4 flex-col items-start">
-        <p className="text-tiny uppercase font-bold">status</p>
-        <small className="text-default-500"></small>
-        <h4>Upcoming reservations</h4>
+        <h4 className="text-foreground-600">Current reservations</h4>
       </CardHeader>
       <CardBody className="overflow-visible py-2">
         <Table
@@ -89,7 +84,6 @@ export default function ReservationWidget() {
         >
           <TableHeader>
             <TableColumn>Name</TableColumn>
-            <TableColumn>Date</TableColumn>
             <TableColumn>Time</TableColumn>
             <TableColumn>Table</TableColumn>
             <TableColumn>Actions</TableColumn>

--- a/client/src/core/utils.ts
+++ b/client/src/core/utils.ts
@@ -69,6 +69,14 @@ export function isUndefined(value: unknown): value is undefined {
     return typeof value === "undefined";
 }
 
+export function isInteger(value: unknown): value is number {
+    return Number(value) === value && value % 1 === 0;
+}
+
+export function isFloat(value: unknown): value is number {
+    return Number(value) === value && value % 1 !== 0;
+}
+
 /**
  * Converts a time string into a formatted time string with hours and minutes.
  *

--- a/client/src/hooks/useQueryReservations.tsx
+++ b/client/src/hooks/useQueryReservations.tsx
@@ -2,14 +2,20 @@ import type { ReservationData } from "@core/types";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { getReq } from "@core/utils";
-import type { AxiosRequestConfig } from "axios";
 
 const queryKey = "reservations";
 
-export default function useQueryReservations<T = ReservationData[]>(interval?: number, params?: AxiosRequestConfig): UseQueryResult<T | undefined> {
+type Params = {
+  /** Will get the number of reservations; Extra params `dateTo` and `dateFrom` can be used to get reservations for specific date range */
+  count?: boolean;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export default function useQueryReservations<T = ReservationData[]>(interval?: number, params?: Params): UseQueryResult<T | undefined> {
   const query = useQuery({
     queryKey: [queryKey, params],
-    queryFn: () => getReq<T>(queryKey, params),
+    queryFn: () => getReq<T>(queryKey, { params }),
     // stop refetching after encountering error
     refetchInterval: (query) => query.state.fetchFailureCount > 0 ? false : interval
   });

--- a/client/src/hooks/useQueryReservations.tsx
+++ b/client/src/hooks/useQueryReservations.tsx
@@ -2,13 +2,14 @@ import type { ReservationData } from "@core/types";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { getReq } from "@core/utils";
+import type { AxiosRequestConfig } from "axios";
 
 const queryKey = "reservations";
 
-export default function useQueryReservations(interval?: number): UseQueryResult<ReservationData[] | undefined> {
+export default function useQueryReservations<T = ReservationData[]>(interval?: number, params?: AxiosRequestConfig): UseQueryResult<T | undefined> {
   const query = useQuery({
-    queryKey: [queryKey],
-    queryFn: () => getReq<ReservationData[]>(queryKey),
+    queryKey: [queryKey, params],
+    queryFn: () => getReq<T>(queryKey, params),
     // stop refetching after encountering error
     refetchInterval: (query) => query.state.fetchFailureCount > 0 ? false : interval
   });

--- a/client/src/hooks/useQueryTables.tsx
+++ b/client/src/hooks/useQueryTables.tsx
@@ -2,13 +2,14 @@ import type { TableData } from "@core/types";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { getReq } from "@core/utils";
+import type { AxiosRequestConfig } from "axios";
 
 const queryKey = "tables";
 
-export default function useQueryTables(interval?: number): UseQueryResult<TableData[] | undefined> {
+export default function useQueryTables<T = TableData[]>(interval?: number, params?: AxiosRequestConfig): UseQueryResult<T | undefined> {
   const query = useQuery({
-    queryKey: [queryKey],
-    queryFn: () => getReq<TableData[]>(queryKey),
+    queryKey: [queryKey, params],
+    queryFn: () => getReq<T>(queryKey, params),
     // stop refetching after encountering error
     refetchInterval: (query) => query.state.fetchFailureCount > 0 ? false : interval
   });

--- a/client/src/hooks/useQueryTables.tsx
+++ b/client/src/hooks/useQueryTables.tsx
@@ -2,14 +2,18 @@ import type { TableData } from "@core/types";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 import { getReq } from "@core/utils";
-import type { AxiosRequestConfig } from "axios";
 
 const queryKey = "tables";
 
-export default function useQueryTables<T = TableData[]>(interval?: number, params?: AxiosRequestConfig): UseQueryResult<T | undefined> {
+type Params = {
+  count?: boolean;
+  capacity?: boolean;
+}
+
+export default function useQueryTables<T = TableData[]>(interval?: number, params?: Params): UseQueryResult<T | undefined> {
   const query = useQuery({
     queryKey: [queryKey, params],
-    queryFn: () => getReq<T>(queryKey, params),
+    queryFn: () => getReq<T>(queryKey, { params }),
     // stop refetching after encountering error
     refetchInterval: (query) => query.state.fetchFailureCount > 0 ? false : interval
   });

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -36,14 +36,13 @@ body {
     @apply border-inherit;
   }
 
-  /* Hide scrollbar for Chrome, Safari and Opera */
-    .no-scrollbar::-webkit-scrollbar {
-        display: none;
-    }
-    /* Hide scrollbar for IE, Edge and Firefox */
-    .no-scrollbar {
-        -ms-overflow-style: none;  /* IE and Edge */
-        scrollbar-width: none;  /* Firefox */
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .no-scrollbar {
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
   }
 }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -35,6 +35,16 @@ body {
   .navigation-link.active {
     @apply border-inherit;
   }
+
+  /* Hide scrollbar for Chrome, Safari and Opera */
+    .no-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+    /* Hide scrollbar for IE, Edge and Firefox */
+    .no-scrollbar {
+        -ms-overflow-style: none;  /* IE and Edge */
+        scrollbar-width: none;  /* Firefox */
+  }
 }
 
 .grid-outer-bg {

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import PageHeader from "@components/PageHeader/PageHeader";
 import ReservationWidget from "@components/Widget/Reservation";
-import MonthReservations from "@components/Minicard/MonthReservations";
+import TotalReservations from "@components/Minicard/TotalReservations";
 import TotalCapacity from "@components/Minicard/TotalCapacity";
 
 export default function DashboardPage(): ReactElement {
@@ -11,11 +11,11 @@ export default function DashboardPage(): ReactElement {
         heading="Dashboard"
       />
       <div className="gap-7 flex flex-row flex-nowrap mb-5 w-full shrink-0 p-1 overflow-auto relative no-scrollbar">
-        <MonthReservations />
+        <TotalReservations />
         <TotalCapacity />
       </div>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-1">
-        <div className="grid gap-4 md:col-span-2">
+      <div className="grid grid-cols-4 md:grid-cols-8 gap-4 p-1">
+        <div className="grid gap-4 col-span-full sm:col-span-6 lg:col-span-4 xl:col-span-3">
           <div className="h-auto max-w-full rounded-lg">
             <ReservationWidget />
           </div>

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -3,6 +3,7 @@ import PageHeader from "@components/PageHeader/PageHeader";
 import ReservationWidget from "@components/Widget/Reservation";
 import MonthReservations from "@components/Minicard/MonthReservations";
 import TotalCapacity from "@components/Minicard/TotalCapacity";
+import TotalTables from "@components/Minicard/TotalTables";
 
 export default function DashboardPage(): ReactElement {
   return (
@@ -12,6 +13,7 @@ export default function DashboardPage(): ReactElement {
       />
       <div className="gap-7 flex flex-row flex-nowrap mb-5 w-full shrink-0 p-1 overflow-auto relative no-scrollbar">
         <MonthReservations />
+        <TotalTables />
         <TotalCapacity />
       </div>
       <div className="grid grid-cols-4 md:grid-cols-8 gap-4 p-1">

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,18 +1,22 @@
 import type { ReactElement } from "react";
 import PageHeader from "@components/PageHeader/PageHeader";
 import ReservationWidget from "@components/Widget/Reservation";
+import MonthReservations from "@components/Minicard/MonthReservations";
+import TotalCapacity from "@components/Minicard/TotalCapacity";
 
 export default function DashboardPage(): ReactElement {
   return (
     <>
       <PageHeader
         heading="Dashboard"
-        subheading="Here you can have an overview of your business analytics, quick actions and more."
       />
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="gap-7 flex flex-row flex-nowrap mb-5 w-full shrink-0 p-1 overflow-auto relative no-scrollbar">
+        <MonthReservations />
+        <TotalCapacity />
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-1">
         <div className="grid gap-4 md:col-span-2">
           <div className="h-auto max-w-full rounded-lg">
-            {/* Render widget here */}
             <ReservationWidget />
           </div>
         </div>

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import PageHeader from "@components/PageHeader/PageHeader";
 import ReservationWidget from "@components/Widget/Reservation";
-import TotalReservations from "@components/Minicard/TotalReservations";
+import MonthReservations from "@components/Minicard/MonthReservations";
 import TotalCapacity from "@components/Minicard/TotalCapacity";
 
 export default function DashboardPage(): ReactElement {
@@ -11,7 +11,7 @@ export default function DashboardPage(): ReactElement {
         heading="Dashboard"
       />
       <div className="gap-7 flex flex-row flex-nowrap mb-5 w-full shrink-0 p-1 overflow-auto relative no-scrollbar">
-        <TotalReservations />
+        <MonthReservations />
         <TotalCapacity />
       </div>
       <div className="grid grid-cols-4 md:grid-cols-8 gap-4 p-1">

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/ReservationController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/ReservationController.java
@@ -81,9 +81,13 @@ public class ReservationController {
   }
 
   @GetMapping
-  public ResponseEntity<?> get(@RequestParam(name = "count", required = false) Boolean count, @RequestParam(name = "date", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
-      if (date != null && count != null && count) {
-          return ResponseEntity.ok().body(reservationService.getCountByDateLessThanEqual(date));
+  public ResponseEntity<?> get(@RequestParam(name = "count", required = false) Boolean count, @RequestParam(name = "dateFrom", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,  @RequestParam(name = "dateTo", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+      if (from != null && to != null && count != null && count) {
+          return ResponseEntity.ok().body(reservationService.getCountByDateBetween(from, to));
+      }
+
+      if (to != null && count != null && count) {
+          return ResponseEntity.ok().body(reservationService.getCountByDateLessThanEqual(to));
       }
 
       if (count != null && count) {

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/ReservationController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/ReservationController.java
@@ -1,6 +1,8 @@
 package com.kalyvianakis.estiator.io.controller;
 
 import java.nio.file.AccessDeniedException;
+import java.sql.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.kalyvianakis.estiator.io.dto.ReservationRequest;
@@ -12,6 +14,7 @@ import com.kalyvianakis.estiator.io.utils.JwtHelper;
 import com.kalyvianakis.estiator.io.utils.ResourceNotFoundException;
 import com.kalyvianakis.estiator.io.model.MessageResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -77,9 +80,17 @@ public class ReservationController {
       return ResponseEntity.ok().body(reservationService.get(id));
   }
 
-  @GetMapping()
-  public ResponseEntity<List<Reservation>> get() {
-    return ResponseEntity.ok().body(reservationService.get());
+  @GetMapping
+  public ResponseEntity<?> get(@RequestParam(name = "count", required = false) Boolean count, @RequestParam(name = "date", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+      if (date != null && count != null && count) {
+          return ResponseEntity.ok().body(reservationService.getCountByDateLessThanEqual(date));
+      }
+
+      if (count != null && count) {
+          return ResponseEntity.ok().body(reservationService.getCount());
+      }
+
+      return ResponseEntity.ok().body(reservationService.get());
   }
 
   @DeleteMapping("/{id}")

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/TableController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/TableController.java
@@ -34,7 +34,10 @@ public class TableController {
     }
 
     @GetMapping()
-    public ResponseEntity<List<Table>> get() {
+    public ResponseEntity<?> get(@RequestParam(name = "capacity", required = false) Boolean count) {
+        if (count != null && count) {
+            return ResponseEntity.ok().body(tableService.getTotalCapacity());
+        }
         return ResponseEntity.ok().body(tableService.get());
     }
 

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/TableController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/TableController.java
@@ -34,8 +34,12 @@ public class TableController {
     }
 
     @GetMapping()
-    public ResponseEntity<?> get(@RequestParam(name = "capacity", required = false) Boolean count) {
+    public ResponseEntity<?> get(@RequestParam(name = "count", required = false) Boolean count, @RequestParam(name = "capacity", required = false) Boolean capacity) {
         if (count != null && count) {
+            return ResponseEntity.ok().body(tableService.count());
+        }
+
+        if (capacity != null && capacity) {
             return ResponseEntity.ok().body(tableService.getTotalCapacity());
         }
         return ResponseEntity.ok().body(tableService.get());

--- a/server/src/main/java/com/kalyvianakis/estiator/io/repository/ReservationRepository.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/repository/ReservationRepository.java
@@ -12,4 +12,5 @@ import java.time.LocalDate;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     Long countByDateLessThanEqual(LocalDate date);
+    Long countByDateBetween(LocalDate from, LocalDate to);
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/repository/ReservationRepository.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/repository/ReservationRepository.java
@@ -1,9 +1,15 @@
 package com.kalyvianakis.estiator.io.repository;
 
+import com.kalyvianakis.estiator.io.enums.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.kalyvianakis.estiator.io.model.Reservation;
 
+import java.sql.Date;
+import java.time.LocalDate;
+
 @Repository
-public interface ReservationRepository extends JpaRepository<Reservation, Long> {}
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    Long countByDateLessThanEqual(LocalDate date);
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/repository/TableRepository.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/repository/TableRepository.java
@@ -2,7 +2,11 @@ package com.kalyvianakis.estiator.io.repository;
 
 import com.kalyvianakis.estiator.io.model.Table;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TableRepository extends JpaRepository<Table, Long> {}
+public interface TableRepository extends JpaRepository<Table, Long> {
+    @Query(value = "SELECT SUM(capacity) FROM Tables", nativeQuery = true)
+    Long getTotalCapacity();
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/ReservationService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/ReservationService.java
@@ -41,6 +41,10 @@ public class ReservationService implements IReservationService {
     return reservationRepository.countByDateLessThanEqual(date);
   }
 
+  public Long getCountByDateBetween(LocalDate from, LocalDate to) {
+    return reservationRepository.countByDateBetween(from, to);
+  }
+
   @Override
   public void delete(Long id) {
     reservationRepository.deleteById(id);

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/ReservationService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/ReservationService.java
@@ -1,7 +1,10 @@
 package com.kalyvianakis.estiator.io.service;
 
+import java.sql.Date;
+import java.time.LocalDate;
 import java.util.List;
 
+import com.kalyvianakis.estiator.io.enums.ReservationStatus;
 import com.kalyvianakis.estiator.io.utils.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,6 +31,14 @@ public class ReservationService implements IReservationService {
   @Override
   public Reservation get(Long id) throws ResourceNotFoundException {
     return reservationRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("Reservation not found for ID: " + id));
+  }
+
+  public Long getCount() {
+    return reservationRepository.count();
+  }
+
+  public Long getCountByDateLessThanEqual(LocalDate date) {
+    return reservationRepository.countByDateLessThanEqual(date);
   }
 
   @Override

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/TableService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/TableService.java
@@ -49,6 +49,10 @@ public class TableService implements ITableService {
         tableRepository.deleteById(id);
     }
 
+    public Long getTotalCapacity() {
+        return tableRepository.getTotalCapacity();
+    }
+
     @Override
     public Boolean exists(Long id) {
         return tableRepository.existsById(id);

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/TableService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/TableService.java
@@ -62,4 +62,6 @@ public class TableService implements ITableService {
     public Boolean notExists(Long id) {
         return !this.exists(id);
     }
+
+    public Long count() { return tableRepository.count(); }
 }


### PR DESCRIPTION
## Description


### Client
This PR is about the implementation of `Minicard` component and using it to display consise information in the Dashboard page. The component has support for displaying a minicard `headline`, `icon`, `description`, while also there is support for an `indicator` component that can display information like percentage changes, or other useful things. 

The components that are implemented using `Minicard` are `MonthReservations` and `TotalCapacity` components which display the reservations of the current month and also the total restaurant capacity.

### Server
The server changes that are part of this MR in order to support client requirements, include: 
- Support for `/reservations?count=true` endpoint which will return the total amount of reservations
- Support for `/reservations?count=true&dateTo=yyyy-MM-dd` which will return the total amount of reservation **up to given date**
- Support for `/reservations?count=true&dateTo=yyyy-MM-dd&dateFrom=yyyy-MM-dd` which will return the total amount of reservation **between the given dates**
- Support for `/tables?capacity=true` which will return the total restaurant capacity (sum of all table capacities)
- Support for `/tables?count=true` which will return the total number of tables

## Screenshots 

**Dashboard page state**
![image](https://github.com/user-attachments/assets/22dec603-3f7f-42d1-8c2e-eaa98f8df53c)

**Zoom in new minicards**
![image](https://github.com/user-attachments/assets/fab53338-60bb-4728-9023-83ac6de22b13)

**Zoom in new minicards with indicator Tooltip on**
![image](https://github.com/user-attachments/assets/1c44b2e0-c141-4da6-aa6f-be3a59bf0994)

