### PR TITLE
Implement Settings page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import CommonLayout from "@layouts/Common";
 import { UserRole } from "@core/types";
 import NotificationProvider from "@context/Notification";
 import CustomerManagementPage from "@pages/CustomerManagement/CustomerManagement";
+import SettingsPage from "@pages/Settings/Settings";
 
 const router = createBrowserRouter([
   {
@@ -57,6 +58,10 @@ const router = createBrowserRouter([
           {
             path: "employees-management/:id",
             element: <EmployeeDetails />
+          },
+          {
+            path: "settings",
+            element: <SettingsPage />
           }
         ]
       },

--- a/client/src/components/DrawerMenu/DrawerMenu.tsx
+++ b/client/src/components/DrawerMenu/DrawerMenu.tsx
@@ -12,10 +12,12 @@ import TableIcon from "@components/Icons/TableIcon";
 import DashboardIcon from "@components/Icons/DashboardIcon";
 import PersonIcon from "@components/Icons/PersonIcon";
 import AdminOnly from "@components/AuthorizationWrappers/AdminOnly";
+import useQuerySettings from "@hooks/useQuerySettings";
 
 export default function DrawerMenu(): ReactElement {
   const navigate = useNavigate();
   const location = useLocation();
+  const { data: settings } = useQuerySettings();
 
   const { open, toggleDrawer } = useDrawer();
 
@@ -48,7 +50,7 @@ export default function DrawerMenu(): ReactElement {
   return (
     <div className={`transition-transform flex flex-col h-full fixed left-0 top-0 max-w-[300px] w-full z-50 bg-slate-800 shadow-2xl px-5 pt-5 pb-2 ${!open ? "translate-x-[-100%]" : ""}`}>
       <div className="mb-5">
-        <CompanyAvatar company={ { name: "Estiator.io", description: "Company description" }} />
+        {settings && <CompanyAvatar company={ { name: settings.businessName, description: settings.businessDescription }} />}
       </div>
       <div className="flex flex-col justify-between h-full">
         <div className="flex flex-col gap-2">

--- a/client/src/components/Fields/Input.tsx
+++ b/client/src/components/Fields/Input.tsx
@@ -1,13 +1,12 @@
 import type { ReactElement } from "react";
 import { Input } from "@heroui/react";
 import type { RegisterOptions } from "react-hook-form";
-import { useFormContext } from "react-hook-form";
-import { getError, hasError } from "@core/utils";
+import { Controller, useFormContext } from "react-hook-form";
 import type { ControlledInputProps } from "@components/Fields/types";
 
 export default function InputField(props: ControlledInputProps): ReactElement {
-    const { name, isRequired, rules, maxLength, minLength, label, ...otherProps } = props;
-    const { register, formState } = useFormContext();
+    const { name, defaultValue, isRequired, rules, maxLength, minLength, label, ...otherProps } = props;
+    const methods = useFormContext();
 
     const { validate, ...restRules } = rules || {};
 
@@ -35,13 +34,25 @@ export default function InputField(props: ControlledInputProps): ReactElement {
     }
 
     return (
-        <Input
-            {...otherProps}
-            {...register(name, defaultRules)}
-            label={label}
-            isRequired={isRequired}
-            isInvalid={hasError(formState, name)}
-            errorMessage={getError(formState, name)}
+        <Controller
+            control={methods.control}
+            name={name}
+            rules={defaultRules}
+            defaultValue={defaultValue}
+            render={({ field: { onChange, onBlur, value, ref }, fieldState: { error, invalid } }) => (
+                <Input
+                    {...otherProps}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    ref={ref}
+                    defaultValue={value}
+                    value={value}
+                    errorMessage={error?.message}
+                    isInvalid={invalid}
+                    isRequired={isRequired}
+                    label={label}
+                />
+            )}
         />
     );
 }

--- a/client/src/components/Fields/Number.tsx
+++ b/client/src/components/Fields/Number.tsx
@@ -18,7 +18,7 @@ export default function NumberField(props: Omit<ControlledInputProps, "type">): 
         } },
         validate: {
             isNumeric: (value: unknown) => {
-                return Number.isNaN(value) ? "Please provide a valid numeric value" : true;
+                return isNaN(Number(value)) ? "Please provide a valid numeric value" : true;
             }
         }
     }

--- a/client/src/components/Fields/Textarea.tsx
+++ b/client/src/components/Fields/Textarea.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from "react";
+import { Textarea } from "@heroui/react";
+import type { RegisterOptions } from "react-hook-form";
+import { Controller, useFormContext } from "react-hook-form";
+import type { ControlledInputProps } from "@components/Fields/types";
+
+export default function TextareaField(props: ControlledInputProps): ReactElement {
+    const { name, defaultValue, isRequired, rules, maxLength, minLength, label, ...otherProps } = props;
+    const methods = useFormContext();
+
+    const { validate, ...restRules } = rules || {};
+
+    const defaultRules: RegisterOptions = {
+        ...restRules,
+        ...(maxLength && !minLength && { maxLength: {
+            message: `${label} cannot exceed ${maxLength} characters.`,
+            value: maxLength
+        } }),
+        ...(minLength && !maxLength && { minLength: {
+            message: `${label} cannot be less than ${maxLength} characters.`,
+            value: minLength
+        } }),
+
+        required: {
+            message: "This field is required",
+            value: isRequired ? isRequired : false
+        },
+
+        validate: {
+            ...validate,
+            ...(minLength && maxLength && {
+                range: (value: string) => value.length >= minLength && value.length <= maxLength ? true : `${label} length must be between ${minLength} and ${maxLength} characters.` })
+        }
+    }
+
+    return (
+        <Controller
+            control={methods.control}
+            name={name}
+            rules={defaultRules}
+            render={({ field: { onChange, onBlur, value, ref }, fieldState: { error, invalid } }) => {
+                return <Textarea
+                    {...otherProps}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    ref={ref}
+                    defaultValue={defaultValue}
+                    value={value}
+                    errorMessage={error?.message}
+                    isInvalid={invalid}
+                    isRequired={isRequired}
+                    label={label}
+                />
+            }}
+        />
+    );
+}

--- a/client/src/components/Loading/Loading.tsx
+++ b/client/src/components/Loading/Loading.tsx
@@ -1,0 +1,26 @@
+import { Spinner } from "@heroui/react";
+import { useEffect, useState } from "react";
+
+export default function Loading() {
+  const [dots, setDots] = useState(0);
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      setDots(oldDots => {
+        return ( oldDots + 1 ) % 4;
+      });
+    }, 500);
+
+    return () => {
+      clearInterval(t);
+    }
+  }, []);
+
+  return (
+    <div className="w-full h-[calc(100vh-300px)] flex justify-center items-center">
+      <div className="flex flex-col gap-5">
+        <Spinner color="current" size="lg" className="mb-2" label={`Loading${".".repeat(dots)}`} />
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/Modal/EditReservation.tsx
+++ b/client/src/components/Modal/EditReservation.tsx
@@ -7,7 +7,6 @@ import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from
 import toParsedTimeString, { getFullName, patchReq } from "@core/utils";
 import type { FieldValues } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
-import InputField from "@components/Fields/Input";
 import NumberField from "@components/Fields/Number";
 import CalendarPlainField from "@components/Fields/CalendarPlain";
 import { parseDate, parseTime } from "@internationalized/date";
@@ -16,6 +15,7 @@ import EmailField from "@components/Fields/Email";
 import { ReservationStatusOption } from "@components/Fields/ReservationStatus";
 import ReservationStatusField from "@components/Fields/ReservationStatus";
 import { useNotification } from "@context/Notification";
+import InputField from "@components/Fields/Input";
 
 type Props = {
   reservation: ReservationData;
@@ -34,6 +34,10 @@ export default function EditReservationModal(props: Props) {
       persons: reservation.persons.toString(),
       table: String(reservation?.table?.id),
       status: reservation.status,
+      name: reservation.createdFor.name,
+      surname: reservation.createdFor.surname,
+      phone: reservation.createdFor.phone,
+      email: reservation.createdFor.email,
       inform: false
     }
   });
@@ -85,7 +89,7 @@ export default function EditReservationModal(props: Props) {
                 <div className="w-full md:w-3/4 md:flex-grow flex flex-col gap-2">
                   <NumberField isRequired label="Persons" name="persons" />
                   <TablesSelect label="Select table" name="table" />
-                  <InputField isReadOnly isDisabled label="Name" name="name"  />
+                  <InputField isReadOnly isDisabled label="Name" name="name" />
                   <InputField isReadOnly isDisabled label="Surname" name="surname" />
                   <EmailField isReadOnly isDisabled label="Email" name="email" />
                   <InputField isReadOnly isDisabled label="Phone" name="phone" />

--- a/client/src/components/Settings/Item.tsx
+++ b/client/src/components/Settings/Item.tsx
@@ -7,11 +7,11 @@ export default function SettingsListItem(props: Props) {
   return (
     <div className="w-full flex flex-row">
       <div className="w-full grid grid-cols-1 gap-2 md:grid-cols-8 md:gap-10 border-b-1 border-foreground-200 py-5">
-        <div className="col-span-3 py-3 pl-1">
-          <h3 className="font-bold text-lg mb-1">{headline}</h3>
-          <p className="text-small text-foreground-400">{description}</p>
+        <div className="col-span-3 pl-1">
+          <h3 className="font-bold text-lg">{headline}</h3>
+          <p className="text-tiny lg:text-sm text-foreground-400">{description}</p>
         </div>
-        <div className="col-span-5 flex items-center">
+        <div className="col-span-5 flex">
           {children}
         </div>
       </div>

--- a/client/src/components/Settings/Item.tsx
+++ b/client/src/components/Settings/Item.tsx
@@ -1,0 +1,20 @@
+import type { PropsWithChildren } from "react";
+
+type Props = PropsWithChildren<{ headline: string, description?: string; }>;
+
+export default function SettingsListItem(props: Props) {
+  const { headline, description, children } = props;
+  return (
+    <div className="w-full flex flex-row">
+      <div className="w-full grid grid-cols-1 gap-2 md:grid-cols-8 md:gap-10 border-b-1 border-foreground-200 py-5">
+        <div className="col-span-3 py-3 pl-1">
+          <h3 className="font-bold text-lg mb-1">{headline}</h3>
+          <p className="text-small text-foreground-400">{description}</p>
+        </div>
+        <div className="col-span-5 flex items-center">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/Settings/List.tsx
+++ b/client/src/components/Settings/List.tsx
@@ -9,14 +9,17 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { patchReq } from "@core/utils";
 import { useEffect } from "react";
 import InputField from "@components/Fields/Input";
+import { useNotification } from "@context/Notification";
 
 export default function SettingsList(props: { settings: SettingsData }) {
   const { settings } = props;
 
   const queryClient = useQueryClient();
+  const { notify } = useNotification();
 
   const methods = useForm({
-    defaultValues: settings
+    defaultValues: settings,
+    mode: "onChange"
   });
 
   useEffect(() => {
@@ -25,11 +28,13 @@ export default function SettingsList(props: { settings: SettingsData }) {
     }
   }, [settings]);
 
-  const enabled = methods.formState.isDirty && methods.formState.isValid;
+  const { isDirty, isValid } = methods.formState;
 
   const { mutateAsync, isPending } = useMutation({
-    mutationFn: (data: SettingsData) => patchReq("settings", data),
-    onSettled: () => queryClient.refetchQueries( { queryKey: ["settings"] }),
+    mutationFn: (data: FieldValues) => patchReq("settings", data),
+    onSettled: () => { queryClient.refetchQueries( { queryKey: ["settings"] }) },
+    onSuccess: () => notify({ message: "Settings were saved successfully.", type: "success" }),
+    onError: () => notify({ message: "Settings could not be saved.", type: "danger" })
   });
 
   async function handleSubmit(e: FieldValues) {
@@ -47,14 +52,14 @@ export default function SettingsList(props: { settings: SettingsData }) {
           <FormProvider {...methods}>
             <form onSubmit={methods.handleSubmit(handleSubmit)} className="my-3">
               <SettingsListItem headline="Business name" description="Provide the name of your business.">
-                <InputField name="businessName" placeholder="Add you business name here..." label="Business name" />
+                <InputField name="businessName" placeholder="Add you business name here..." label="Business name" isRequired maxLength={30} minLength={3} />
               </SettingsListItem>
               <SettingsListItem headline="Business description" description="Provide a brief description of your business. This text will appear in emails and various sections of the admin dashboard.">
-                <TextareaField name="businessDescription" placeholder="Add you business description here..." label="Business description" />
+                <TextareaField maxLength={40} name="businessDescription" placeholder="Add you business description here..." label="Business description" />
               </SettingsListItem>
               <div className="py-10 flex gap-3 justify-end">
-                <Button color="primary" type="submit" isLoading={isPending} isDisabled={!enabled}>Save settings</Button>
-                <Button color="default" onPress={handleReset}>Reset</Button>
+                <Button color="primary" type="submit" isLoading={isPending} isDisabled={!isDirty || !isValid}>Save settings</Button>
+                <Button color="default" onPress={handleReset} isDisabled={!isDirty}>Reset</Button>
               </div>
             </form>
             <DevTool control={methods.control} />

--- a/client/src/components/Settings/List.tsx
+++ b/client/src/components/Settings/List.tsx
@@ -1,7 +1,6 @@
 import TextareaField from "@components/Fields/Textarea";
 import type { SettingsData } from "@core/types";
 import { Tabs, Tab, Button } from "@heroui/react";
-import { DevTool } from "@hookform/devtools";
 import type { FieldValues } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
 import SettingsListItem from "./Item";
@@ -62,7 +61,6 @@ export default function SettingsList(props: { settings: SettingsData }) {
                 <Button color="default" onPress={handleReset} isDisabled={!isDirty}>Reset</Button>
               </div>
             </form>
-            <DevTool control={methods.control} />
           </FormProvider>
         </Tab>
       </Tabs>

--- a/client/src/components/Settings/List.tsx
+++ b/client/src/components/Settings/List.tsx
@@ -1,0 +1,66 @@
+import TextareaField from "@components/Fields/Textarea";
+import type { SettingsData } from "@core/types";
+import { Tabs, Tab, Button } from "@heroui/react";
+import { DevTool } from "@hookform/devtools";
+import type { FieldValues } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import SettingsListItem from "./Item";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { patchReq } from "@core/utils";
+import { useEffect } from "react";
+import InputField from "@components/Fields/Input";
+
+export default function SettingsList(props: { settings: SettingsData }) {
+  const { settings } = props;
+
+  const queryClient = useQueryClient();
+
+  const methods = useForm({
+    defaultValues: settings
+  });
+
+  useEffect(() => {
+    if (settings) {
+      methods.reset(settings);
+    }
+  }, [settings]);
+
+  const enabled = methods.formState.isDirty && methods.formState.isValid;
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: (data: SettingsData) => patchReq("settings", data),
+    onSettled: () => queryClient.refetchQueries( { queryKey: ["settings"] }),
+  });
+
+  async function handleSubmit(e: FieldValues) {
+    await mutateAsync(e);
+  }
+
+  function handleReset() {
+    methods.reset(settings, { keepDefaultValues: true, keepDirty: false });
+  }
+
+  return (
+    <div className="flex w-full flex-col">
+      <Tabs aria-label="Options">
+        <Tab key="business" title="Preferences">
+          <FormProvider {...methods}>
+            <form onSubmit={methods.handleSubmit(handleSubmit)} className="my-3">
+              <SettingsListItem headline="Business name" description="Provide the name of your business.">
+                <InputField name="businessName" placeholder="Add you business name here..." label="Business name" />
+              </SettingsListItem>
+              <SettingsListItem headline="Business description" description="Provide a brief description of your business. This text will appear in emails and various sections of the admin dashboard.">
+                <TextareaField name="businessDescription" placeholder="Add you business description here..." label="Business description" />
+              </SettingsListItem>
+              <div className="py-10 flex gap-3 justify-end">
+                <Button color="primary" type="submit" isLoading={isPending} isDisabled={!enabled}>Save settings</Button>
+                <Button color="default" onPress={handleReset}>Reset</Button>
+              </div>
+            </form>
+            <DevTool control={methods.control} />
+          </FormProvider>
+        </Tab>
+      </Tabs>
+    </div>
+  )
+}

--- a/client/src/context/Notification.tsx
+++ b/client/src/context/Notification.tsx
@@ -14,7 +14,7 @@ type NotificationValue = {
     notify: (notification: Notification) => void;
 }
 
-const NotificationContext = createContext<NotificationValue>({ notify: () => {} });
+const NotificationContext = createContext<NotificationValue>({ notify: () => { } });
 
 /** The amount of time for notifications to stay visible notification center */
 const NOTIFICATION_DELAY = 5000;
@@ -32,13 +32,13 @@ function NotificationProvider(props: PropsWithChildren) {
     return <NotificationContext.Provider value={{ notify }}>
         {props.children}
 
-        {notifications.length > 0 && <div key={"primary"} className="w-[450px] flex items-center fixed z-[99999] bottom-[15px] right-[15px]">
+        {notifications.length > 0 && <div key={"primary"} className="w-150px sm:w-[450px] flex items-center fixed z-[99999] bottom-[15px] right-[15px]">
             <div className="w-full flex flex-col-reverse gap-2">
                 {notifications.map((item, index) => {
                     return (<TimeLimited key={index} delay={NOTIFICATION_DELAY}>
-                        <Alert color={item.type ?? "default"} description={item.description} title={item.message} className="shadow-xl" />
+                        <Alert key={index} color={item.type ?? "default"} classNames={{ title: "text-tiny sm:text-sm" }} description={item.description} title={item.message} className="shadow-xl" />
                     </TimeLimited>
-                )
+                    )
                 })}
             </div>
         </div>}

--- a/client/src/core/types.ts
+++ b/client/src/core/types.ts
@@ -126,7 +126,12 @@ export type CompanyData = {
   description: string;
 };
 
-export type SettingsData = Record<string, string>;
+export enum AppSetting {
+  BusinessName = "businessName",
+  BusinessDescription = "businessDescription"
+}
+
+export type SettingsData = Record<AppSetting, string>;
 
 /** Represents statuses of reservations */
 export enum ReservationStatus {

--- a/client/src/core/types.ts
+++ b/client/src/core/types.ts
@@ -126,6 +126,8 @@ export type CompanyData = {
   description: string;
 };
 
+export type SettingsData = Record<string, string>;
+
 /** Represents statuses of reservations */
 export enum ReservationStatus {
   CANCELLED = "Cancelled",

--- a/client/src/hooks/useQuerySetting.tsx
+++ b/client/src/hooks/useQuerySetting.tsx
@@ -1,0 +1,19 @@
+import type { SettingsData } from "@core/types";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { getReq } from "@core/utils";
+
+type Params = Record<string, unknown>;
+
+export default function useQuerySetting(id: string | undefined, params?: Params, interval?: number): UseQueryResult<SettingsData | undefined> {
+
+  const queryKey = `settings/${id}`;
+  const query = useQuery({
+    queryKey: [queryKey],
+    queryFn: () => getReq<SettingsData>(queryKey, { params }),
+    // stop refetching after encountering error
+    refetchInterval: (query) => query.state.fetchFailureCount > 0 ? false : interval
+  });
+
+  return query;
+}

--- a/client/src/hooks/useQuerySettings.tsx
+++ b/client/src/hooks/useQuerySettings.tsx
@@ -1,0 +1,20 @@
+import type { SettingsData } from "@core/types";
+import type { UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { getReq } from "@core/utils";
+
+type Params = Record<string, unknown>;
+
+export default function useQuerySettings<T = SettingsData>(interval?: number, options?: Omit<UseQueryOptions<T>, "queryKey" | "queryFn">, params?: Params): UseQueryResult<T | undefined> {
+
+  const queryKey = `settings`;
+  const query = useQuery({
+    ...options,
+    queryKey: [queryKey],
+    queryFn: () => getReq<T>(queryKey, { params }),
+    // stop refetching after encountering error
+    refetchInterval: (query) => query.state.fetchFailureCount > 0 ? false : interval
+  });
+
+  return query;
+}

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -1,0 +1,21 @@
+import { type ReactElement } from "react";
+import PageHeader from "@components/PageHeader/PageHeader";
+import useQuerySettings from "@hooks/useQuerySettings";
+import SettingsList from "@components/Settings/List";
+import { isUndefined } from "@core/utils";
+import Blank from "@components/Blank/Blank";
+import HomeIcon from "@components/Icons/HomeIcon";
+
+export default function SettingsPage(): ReactElement {
+  const { data: settings } = useQuerySettings();
+
+  return (
+    <>
+      <PageHeader
+        heading="Settings"
+        subheading="Manage your business details and preferences here."
+      />
+      {!isUndefined(settings) ? <SettingsList settings={settings} /> : <Blank title="Loading" icon={<HomeIcon />} />}
+    </>
+  );
+}

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -3,8 +3,7 @@ import PageHeader from "@components/PageHeader/PageHeader";
 import useQuerySettings from "@hooks/useQuerySettings";
 import SettingsList from "@components/Settings/List";
 import { isUndefined } from "@core/utils";
-import Blank from "@components/Blank/Blank";
-import HomeIcon from "@components/Icons/HomeIcon";
+import Loading from "@components/Loading/Loading";
 
 export default function SettingsPage(): ReactElement {
   const { data: settings } = useQuerySettings();
@@ -15,7 +14,7 @@ export default function SettingsPage(): ReactElement {
         heading="Settings"
         subheading="Manage your business details and preferences here."
       />
-      {!isUndefined(settings) ? <SettingsList settings={settings} /> : <Blank title="Loading" icon={<HomeIcon />} />}
+      {!isUndefined(settings) ? <SettingsList settings={settings} /> : <Loading />}
     </>
   );
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/SettingController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/SettingController.java
@@ -1,0 +1,52 @@
+package com.kalyvianakis.estiator.io.controller;
+
+import com.kalyvianakis.estiator.io.model.Setting;
+import com.kalyvianakis.estiator.io.service.SettingService;
+import com.kalyvianakis.estiator.io.utils.ResourceNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@CrossOrigin
+@RequestMapping("settings")
+public class SettingController {
+
+    @Autowired
+    SettingService settingService;
+
+    @GetMapping
+    public ResponseEntity<Map<String, String>> get() {
+        List<Setting> settings = settingService.findAll();
+        HashMap<String, String> json = new HashMap<>();
+        settings.forEach(setting -> {
+            json.put(setting.getId(), setting.getValue());
+        });
+        return ResponseEntity.ok().body(json);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Setting> get(@PathVariable(name = "id") String id) throws ResourceNotFoundException {
+        return ResponseEntity.ok().body(settingService.findById(id).orElseThrow(() -> new ResourceNotFoundException("Setting not found for ID: " + id)));
+    }
+
+    @PatchMapping()
+    public ResponseEntity<ResponseEntity.BodyBuilder> patch(@RequestBody Map<String, String> data) throws ResourceNotFoundException {
+        List<Setting> settings = new ArrayList<>();
+        for(Map.Entry<String, String> entry: data.entrySet()) {
+            if (!settingService.exists(entry.getKey())) {
+                throw new ResourceNotFoundException("User not found for ID: " + entry.getKey());
+            }
+            Setting setting = new Setting();
+            setting.setId(entry.getKey());
+            setting.setValue(entry.getValue());
+            settings.add(setting);
+        }
+
+        settingService.saveAll(settings);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/model/Setting.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/model/Setting.java
@@ -1,0 +1,31 @@
+package com.kalyvianakis.estiator.io.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.kalyvianakis.estiator.io.utils.PropertyPrinter;
+import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "settings")
+public class Setting extends PropertyPrinter {
+    @Id
+    private String id;
+
+    private String value;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/repository/SettingRepository.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/repository/SettingRepository.java
@@ -1,0 +1,13 @@
+package com.kalyvianakis.estiator.io.repository;
+
+import com.kalyvianakis.estiator.io.model.Reservation;
+import com.kalyvianakis.estiator.io.model.Setting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SettingRepository extends JpaRepository<Setting, String> {}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/ISettingService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/ISettingService.java
@@ -1,0 +1,7 @@
+package com.kalyvianakis.estiator.io.service;
+
+import com.kalyvianakis.estiator.io.model.Setting;
+
+public interface ISettingService {
+    Setting save(Setting setting);
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/SettingService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/SettingService.java
@@ -1,0 +1,41 @@
+package com.kalyvianakis.estiator.io.service;
+
+import com.kalyvianakis.estiator.io.model.Reservation;
+import com.kalyvianakis.estiator.io.model.Setting;
+import com.kalyvianakis.estiator.io.repository.ReservationRepository;
+import com.kalyvianakis.estiator.io.repository.SettingRepository;
+import com.kalyvianakis.estiator.io.utils.ResourceNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SettingService implements ISettingService {
+
+  @Autowired
+  SettingRepository settingRepository;
+
+  @Override
+  public Setting save(Setting setting) {
+    return settingRepository.save(setting);
+  }
+
+  public void saveAll(List<Setting> settings) {
+    settingRepository.saveAll(settings);
+  }
+
+  public Optional<Setting> findById(String id) {
+    return settingRepository.findById(id);
+  }
+
+  public List<Setting> findAll() {
+    return settingRepository.findAll();
+  }
+
+  public Boolean exists(String id) {
+    return settingRepository.existsById(id);
+  }
+}


### PR DESCRIPTION
## Description 

This PR is about the implementation of `Settings` page and the API to support it. The following are included: 

- Refactoring of `Input` field to use `Controller` in order to fix various bugs coming from incompatibilities of `HeroUI` input field and `react-hook-forms` package
- Implementation of a general `Loading` component as fallback.
- Implementation of `/settings` endpoint with: 
  - `GET /settings` - Get all settings in a Map structure.
  - `GET /settings/{id}` - Get single setting.
  - `PATCH /settings` - Update current settings
- Implemented types to support `Settings` in the client. 

An enum called `AppSetting` has been also added in the client. This will hold all available settings that exist on the database and make it easier for client code to get access to the available settings. The server will not be able to create new settings (only `PATCH` is supported), unless they are explicitly added in the database on creation or after update.


## Screenshots

![screencapture-localhost-3000-settings-2025-02-03-17_23_35](https://github.com/user-attachments/assets/dce4f715-2265-4fec-b9fc-7e5d895d6a02)

