### PR TITLE
Increase JWT lifetime

### DIFF
--- a/server/src/main/java/com/kalyvianakis/estiator/io/utils/JwtHelper.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/utils/JwtHelper.java
@@ -21,7 +21,7 @@ public class JwtHelper {
     @Autowired
     ApplicationProperties applicationProperties;
 
-    private static final Integer MINUTES = 60;
+    private static final Integer DAYS = 3;
 
     public String generateToken(User user) {
         Instant now = Instant.now();
@@ -30,7 +30,7 @@ public class JwtHelper {
                 .subject(authUser.getEmail())
                 .claim("user", authUser)
                 .issuedAt(Date.from(now))
-                .expiration(Date.from(now.plus(MINUTES, ChronoUnit.MINUTES)))
+                .expiration(Date.from(now.plus(DAYS, ChronoUnit.DAYS)))
                 .signWith(SignatureAlgorithm.HS256, applicationProperties.getJwtSecret())
                 .compact();
     }


### PR DESCRIPTION
## Description 
This PR increases the JWT lifetime from 60 minutes to 3 days  in order to prevent users from having to login too frequently.

## Additional info
A more secure approach would be to set the token expiration to a fixed period (e.g., 24 hours) while also refreshing the token each time the user returns to the app. This minimizes the window of opportunity for an attacker while ensuring a seamless experience for the user, reducing the need for frequent logins.