### PR TITLE
Implement Employees Status dashboard widget

### DIFF
--- a/client/src/components/EmployeeCalendar/EmployeeCalendar.tsx
+++ b/client/src/components/EmployeeCalendar/EmployeeCalendar.tsx
@@ -1,6 +1,6 @@
 import IconButton from "@components/IconButton/IconButton";
 import { DeleteIcon } from "@components/Icons/DeleteIcon";
-import { ScheduleStatus, type Schedule, type UserData } from "@core/types";
+import { ScheduleStatus, ScheduleStatuses, type Schedule, type UserData } from "@core/types";
 import { dayToString, deleteReq, toParsedTimeString } from "@core/utils";
 import useQueryUserScheduleByDate from "@hooks/useQueryUserScheduleByDate";
 import { getDayOfWeek, getLocalTimeZone, today } from "@internationalized/date";
@@ -106,7 +106,9 @@ export default function EmployeeCalendar({ user }: Props) {
                   </Chip>
                 </TableCell>
                 <TableCell className="w-[40%]" textValue="Status">
-                  <Chip variant="dot" color={schedule.status == ScheduleStatus.Working ? "success" : schedule.status == ScheduleStatus.Sick ? "warning" : "primary"}>{schedule.status}</Chip>
+                  <Chip variant="dot" color={schedule.status == ScheduleStatus.WORKING ? "success" : schedule.status == ScheduleStatus.SICK ? "warning" : "primary"}>
+                    {ScheduleStatuses[schedule.status]}
+                    </Chip>
                 </TableCell>
                 <TableCell className="w-[40%]" textValue="Actions">
                   <IconButton

--- a/client/src/components/EmployeeSchedule/EmployeeSchedule.tsx
+++ b/client/src/components/EmployeeSchedule/EmployeeSchedule.tsx
@@ -103,9 +103,9 @@ export default function EmployeeSchedule({ employee }: Props) {
             <div className="w-full p-1">
               <div className="w-full flex-nowrap flex gap-2 mb-3">
                 <SelectField name="scheduleStatus" label="Schedule status" isRequired>
-                  <SelectItem key={ScheduleStatus.Working}>Working</SelectItem>
-                  <SelectItem key={ScheduleStatus.OnLeave}>On Leave</SelectItem>
-                  <SelectItem key={ScheduleStatus.Sick}>Sick</SelectItem>
+                  <SelectItem key={ScheduleStatus.WORKING}>Working</SelectItem>
+                  <SelectItem key={ScheduleStatus.ON_LEAVE}>On Leave</SelectItem>
+                  <SelectItem key={ScheduleStatus.SICK}>Sick</SelectItem>
                 </SelectField>
               </div>
             </div>

--- a/client/src/components/Icons/ResetIcon.tsx
+++ b/client/src/components/Icons/ResetIcon.tsx
@@ -1,0 +1,18 @@
+import type { SVGProps } from "react";
+
+export function ResetIcon(props: SVGProps<SVGSVGElement>) {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="1em"
+        height="1em"
+        {...props}
+      >
+        <path
+          fill="currentColor"
+          d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12S6.477 2 12 2v2a8 8 0 1 0 5.135 1.865L15 8V2h6l-2.447 2.447A9.98 9.98 0 0 1 22 12"
+        ></path>
+      </svg>
+    )
+  }

--- a/client/src/components/Widget/EmployeesStatus.tsx
+++ b/client/src/components/Widget/EmployeesStatus.tsx
@@ -1,0 +1,145 @@
+import { ScheduleStatus, ScheduleStatuses, type Schedule } from "@core/types";
+import { dayToString, getFullName, toParsedTimeString } from "@core/utils";
+import { getDayOfWeek, getLocalTimeZone, today } from "@internationalized/date";
+import {
+  Button,
+  ButtonGroup,
+  Chip,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  User,
+} from "@heroui/react";
+import { useCallback, useState } from "react";
+import useQuerySchedules from "@hooks/useQuerySchedules";
+import { ResetIcon } from "@components/Icons/ResetIcon";
+import { Link } from "react-router-dom";
+
+const columns = [
+  { name: "EMPLOYEE", uid: "employee" },
+  { name: "ROLE", uid: "role" },
+  { name: "START TIME", uid: "startTime" },
+  { name: "END TIME", uid: "endTime" },
+  { name: "STATUS", uid: "status" },
+];
+
+export default function EmployeesStatusWidget() {
+  const [current, setCurrent] = useState(0);
+  const currentDate = today(getLocalTimeZone()).add({ days: current });
+  const previousDate = currentDate.subtract({ days: 1 });
+  const nextDate = currentDate.add({ days: 1 });
+
+  const { data: schedules, isLoading } = useQuerySchedules(3000, {}, { date: currentDate.toString() });
+
+  const renderRow = useCallback((schedule: Schedule) => {
+    return (
+      <TableRow key={schedule.id.toString()}>
+        <TableCell className="w-[30%]" textValue="Date">
+          <User
+            avatarProps={{ radius: "full", size: "sm" }}
+            classNames={{
+              description: "text-default-500"
+            }}
+            description={schedule.user?.email || schedule.user?.phone}
+            name={getFullName(schedule.user)}
+          />
+        </TableCell>
+        <TableCell className="w-[30%]" textValue="Start Time">
+          <p className="text-tiny">
+            {schedule.user.position}
+          </p>
+        </TableCell>
+        <TableCell className="w-[10%]" textValue="Start Time">
+            {toParsedTimeString(schedule.startTime)}
+        </TableCell>
+        <TableCell className="w-[10%]" textValue="End Time">
+            {toParsedTimeString(schedule.endTime)}
+        </TableCell>
+        <TableCell className="w-[10%]" textValue="Status">
+          <Chip variant="dot" color={schedule.status == ScheduleStatus.WORKING ? "success" : schedule.status == ScheduleStatus.SICK ? "warning" : "primary"}>
+            {ScheduleStatuses[schedule.status]}
+          </Chip>
+        </TableCell>
+      </TableRow>
+    )
+  }, [schedules])
+
+  function TopContent() {
+    return (
+      <div className="flex flex-col gap-4">
+        <div>
+          <h4 className="text-foreground-500 font-bold">Daily Employees</h4>
+          <p className="mt-0 text-xs text-slate-400">View the daily status of your employees.</p>
+        </div>
+        <div className="flex-grow w-full">
+          <ButtonGroup fullWidth>
+            <Button isIconOnly color="warning" variant="solid" isDisabled disableRipple disableAnimation />
+            <Button color="default" variant="flat" onPress={() => setCurrent(current - 1)}>
+              <div className="flex flex-col w-full box-border text-center">
+                <h5 className="m-0 text-[0.8rem]">
+                  {dayToString(getDayOfWeek(previousDate, "en-UK"))}
+                </h5>
+                <p className="text-[0.8rem] m-0">{previousDate.toString()}</p>
+              </div>
+            </Button>
+            <Button color="primary" variant="solid">
+              <div className="flex flex-col w-full box-border text-center">
+                <h3 className="m-0">
+                  {dayToString(getDayOfWeek(currentDate, "en-UK"))}
+                </h3>
+                <p className="text-[1rem] m-0">{currentDate.toString()}</p>
+              </div>
+            </Button>
+            <Button color="default" variant="flat" onPress={() => setCurrent(current + 1)}>
+              <div className="flex flex-col w-full box-border text-center">
+                <h3 className="m-0 text-[0.8rem]">
+                  {dayToString(getDayOfWeek(nextDate, "en-UK"))}
+                </h3>
+                <p className="text-[0.8rem] m-0">{nextDate.toString()}</p>
+              </div>
+            </Button>
+            <Tooltip content="Reset to current date" showArrow placement="right">
+              <Button isIconOnly color="warning" onPress={() => setCurrent(0)}>
+                <ResetIcon />
+              </Button>
+            </Tooltip>
+          </ButtonGroup>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Table
+      classNames={{ emptyWrapper: "h-16" }}
+      aria-label="Example table with custom cells"
+      topContent={<TopContent />}
+      bottomContentPlacement="outside"
+      bottomContent={<small><Link className="text-primary px-1" to={"/employees-management"}>View employees management</Link></small>}
+    >
+      <TableHeader columns={columns}>
+        {(column) => (
+          <TableColumn
+            key={column.uid}
+            align={column.uid === "actions" ? "center" : "start"}
+          >
+            {column.name}
+          </TableColumn>
+        )}
+      </TableHeader>
+      <TableBody
+        emptyContent={<p>No schedules on current date</p>}
+        isLoading={isLoading}
+        items={(schedules || []) as Iterable<Schedule>}
+        loadingContent={<Spinner label="Loading..." />}
+      >
+        {(schedule: Schedule) => renderRow(schedule)}
+      </TableBody>
+    </Table>
+  );
+}

--- a/client/src/components/Widget/EmployeesStatus.tsx
+++ b/client/src/components/Widget/EmployeesStatus.tsx
@@ -119,7 +119,6 @@ export default function EmployeesStatusWidget() {
       classNames={{ emptyWrapper: "h-16" }}
       aria-label="Example table with custom cells"
       topContent={<TopContent />}
-      bottomContentPlacement="outside"
       bottomContent={<small><Link className="text-primary px-1" to={"/employees-management"}>View employees management</Link></small>}
     >
       <TableHeader columns={columns}>

--- a/client/src/components/Widget/EmployeesStatus.tsx
+++ b/client/src/components/Widget/EmployeesStatus.tsx
@@ -21,11 +21,11 @@ import { ResetIcon } from "@components/Icons/ResetIcon";
 import { Link } from "react-router-dom";
 
 const columns = [
-  { name: "EMPLOYEE", uid: "employee" },
-  { name: "ROLE", uid: "role" },
-  { name: "START TIME", uid: "startTime" },
-  { name: "END TIME", uid: "endTime" },
-  { name: "STATUS", uid: "status" },
+  { name: "Employee", uid: "employee" },
+  { name: "Role", uid: "role" },
+  { name: "Start Time", uid: "startTime" },
+  { name: "End Time", uid: "endTime" },
+  { name: "Status", uid: "status" },
 ];
 
 export default function EmployeesStatusWidget() {
@@ -104,8 +104,8 @@ export default function EmployeesStatusWidget() {
               </div>
             </Button>
             <Tooltip content="Reset to current date" showArrow placement="right">
-              <Button isIconOnly color="warning" onPress={() => setCurrent(0)}>
-                <ResetIcon />
+              <Button isIconOnly color="warning" className="text-background" onPress={() => setCurrent(0)}>
+                <ResetIcon className="text-lg" />
               </Button>
             </Tooltip>
           </ButtonGroup>

--- a/client/src/components/Widget/Reservation.tsx
+++ b/client/src/components/Widget/Reservation.tsx
@@ -101,8 +101,9 @@ export default function ReservationWidget() {
 
   return (
     <Table
+      isCompact
       topContent={<div>
-        <h4 className="text-foreground-600">Current daily reservations</h4>
+        <h4 className="text-foreground-500 font-bold">Current daily reservations</h4>
         <p className="mt-0 text-xs text-slate-400">View the upcoming and active reservations in real time.</p>
       </div>}
       isStriped

--- a/client/src/components/Widget/TableAvailability.tsx
+++ b/client/src/components/Widget/TableAvailability.tsx
@@ -35,7 +35,7 @@ export default function TableAvailabilityWidget() {
 
   return <Card shadow="sm">
     <CardHeader className="flex flex-col items-start">
-      <h4 className="text-foreground-600">Table availability</h4>
+      <h4 className="text-foreground-500 font-bold">Table availability</h4>
       <p className="mt-0 text-xs text-slate-400">View the real-time occupied and available tables.</p>
     </CardHeader>
     <CardBody className="py-8 flex gap-5">

--- a/client/src/context/Notification.tsx
+++ b/client/src/context/Notification.tsx
@@ -36,7 +36,7 @@ function NotificationProvider(props: PropsWithChildren) {
             <div className="w-full flex flex-col-reverse gap-2">
                 {notifications.map((item, index) => {
                     return (<TimeLimited key={index} delay={NOTIFICATION_DELAY}>
-                        <Alert key={index} color={item.type ?? "default"} classNames={{ title: "text-tiny sm:text-sm" }} description={item.description} title={item.message} className="shadow-xl" />
+                        <Alert isClosable key={index} color={item.type ?? "default"} classNames={{ title: "text-tiny sm:text-sm" }} description={item.description} title={item.message} className="shadow-xl" />
                     </TimeLimited>
                     )
                 })}

--- a/client/src/core/types.ts
+++ b/client/src/core/types.ts
@@ -72,16 +72,23 @@ export interface UserData extends HasId {
 };
 
 export enum ScheduleStatus {
-  Working = "Working",
-  OnLeave = "On_Leave",
-  Sick = "Sick"
+  WORKING = "Working",
+  ON_LEAVE = "On_Leave",
+  SICK = "Sick"
+};
+
+export const ScheduleStatuses = {
+  [ScheduleStatus.WORKING]: "Working",
+  [ScheduleStatus.ON_LEAVE]: "On Leave",
+  [ScheduleStatus.SICK]: "Sick"
 };
 
 export interface Schedule extends HasId {
   date: string;
   startTime: string;
   endTime: string;
-  status: ScheduleStatus
+  status: ScheduleStatus;
+  user: UserData;
 }
 
 export interface EmployeeData extends HasId {
@@ -99,7 +106,7 @@ export interface EmployeeData extends HasId {
 
 export enum EmployeeStatus {
   ACTIVE = "Active",
-  ON_LEAVE = "On_leave",
+  ON_LEAVE = "On_Leave",
   TERMINATED = "Terminated"
 };
 

--- a/client/src/hooks/useQuerySchedules.tsx
+++ b/client/src/hooks/useQuerySchedules.tsx
@@ -1,0 +1,22 @@
+import type { TableData } from "@core/types";
+import type { UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { getReq } from "@core/utils";
+
+const queryKey = "schedules";
+
+type Params = {
+  date?: string;
+}
+
+export default function useQuerySchedules<T = TableData[]>(interval?: number, options?: Omit<UseQueryOptions<T>, "queryKey" | "queryFn">, params?: Params): UseQueryResult<T | undefined> {
+  const query = useQuery({
+    ...options,
+    queryKey: [queryKey, params],
+    queryFn: () => getReq<T>(queryKey, { params }),
+    // stop refetching after encountering error
+    refetchInterval: (query) => query.state.fetchFailureCount > 0 ? false : interval,
+  });
+
+  return query;
+}

--- a/client/src/hooks/useQueryTables.tsx
+++ b/client/src/hooks/useQueryTables.tsx
@@ -20,7 +20,6 @@ type Params = {
 }
 
 export default function useQueryTables<T = TableData[]>(interval?: number, options?: Omit<UseQueryOptions<T>, "queryKey" | "queryFn">, params?: Params): UseQueryResult<T | undefined> {
-// export default function useQueryTables<T = TableData[]>(interval?: number, params?: Params): UseQueryResult<T | undefined> {
   const query = useQuery({
     ...options,
     queryKey: [queryKey, params],

--- a/client/src/layouts/Private/MainContent.tsx
+++ b/client/src/layouts/Private/MainContent.tsx
@@ -11,7 +11,7 @@ export default function MainContent() {
     <div className={`main min-h-screen flex flex-col transition-all ${open ? "pl-[300px]" : ""}`}>
       <Navigation />
       <DrawerMenu />
-      <div className="container max-w-[1400px] mx-auto px-5 mt-7 flex-grow">
+      <div className="container max-w-[1540px] mx-auto px-5 mt-7 flex-grow">
         <Outlet />
       </div>
       <Footer />

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -5,6 +5,7 @@ import MonthReservations from "@components/Minicard/MonthReservations";
 import TotalCapacity from "@components/Minicard/TotalCapacity";
 import TotalTables from "@components/Minicard/TotalTables";
 import TableAvailabilityWidget from "@components/Widget/TableAvailability";
+import EmployeesStatusWidget from "@components/Widget/EmployeesStatus";
 
 export default function DashboardPage(): ReactElement {
   return (
@@ -18,10 +19,15 @@ export default function DashboardPage(): ReactElement {
         <TotalCapacity />
       </div>
       <div className="grid grid-cols-4 md:grid-cols-12 gap-8 p-1">
-        <div className="gap-4 col-span-full sm:col-span-12 md:col-span-12 lg:col-span-10 xl:col-span-7">
-          <ReservationWidget />
+        <div className="gap-8 col-span-full sm:col-span-12 md:col-span-12 lg:col-span-10 xl:col-span-7 grid grid-cols-8">
+          <div className="col-span-full">
+            <ReservationWidget />
+          </div>
+          <div className="col-span-6">
+            <EmployeesStatusWidget />
+          </div>
         </div>
-        <div className="gap-4 col-span-full sm:col-span-8 md:col-span-9 lg:col-span-7 xl:col-span-4">
+        <div className="gap-4 col-span-full sm:col-span-8 md:col-span-9 lg:col-span-7 xl:col-span-3">
           <TableAvailabilityWidget />
         </div>
       </div>

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/ScheduleController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/ScheduleController.java
@@ -6,10 +6,12 @@ import com.kalyvianakis.estiator.io.model.MessageResponse;
 import com.kalyvianakis.estiator.io.model.Schedule;
 import com.kalyvianakis.estiator.io.service.ScheduleService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -34,9 +36,13 @@ public class ScheduleController {
     }
 
     @GetMapping()
-    public ResponseEntity<List<Schedule>> get() {
+    public ResponseEntity<List<Schedule>> get(@RequestParam(name = "date", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        if (date != null) {
+            return ResponseEntity.ok().body(scheduleService.getAllByDate(date));
+        }
         return ResponseEntity.ok().body(scheduleService.get());
     }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<?> delete(@PathVariable Long id) throws ResourceNotFoundException, IllegalArgumentException {
         if(scheduleService.notExists(id)) {

--- a/server/src/main/java/com/kalyvianakis/estiator/io/model/Schedule.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/model/Schedule.java
@@ -23,7 +23,7 @@ public class Schedule extends PropertyPrinter {
     @ManyToOne
     @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
     @JsonIgnoreProperties(value = { "tables", "reservations", "createdReservations", "referredReservations", "schedules" })
-    @JsonProperty(value = "user", access = JsonProperty.Access.WRITE_ONLY)
+    @JsonProperty(value = "user")
     private User user;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/server/src/main/java/com/kalyvianakis/estiator/io/repository/ScheduleRepository.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/repository/ScheduleRepository.java
@@ -1,10 +1,13 @@
 package com.kalyvianakis.estiator.io.repository;
 
 import com.kalyvianakis.estiator.io.model.Schedule;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -15,4 +18,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long>, JpaSp
     List<Schedule> findByUserId(Long userId, Sort sort);
     Schedule findByUserIdAndDate(Long userId, LocalDate date);
     List<Schedule> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+
+    @Query(
+            value = "SELECT s.* FROM schedules s\n" +
+                    "LEFT JOIN users u ON s.user_id = u.id\n" +
+                    "WHERE u.user_role IN(:roles) AND s.date = :date", nativeQuery = true)
+    List<Schedule> findAllByUserRoleAndDate(@Param(value = "roles") List<String> roles, @Param(value = "date") LocalDate date);
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/ScheduleService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/ScheduleService.java
@@ -51,4 +51,8 @@ public class ScheduleService implements IScheduleService {
     return !this.exists(id);
   }
 
+  public List<Schedule> getAllByDate(LocalDate date) {
+    List<String> roles = List.of("ROLE_ADMIN", "ROLE_MODERATOR");
+    return scheduleRepository.findAllByUserRoleAndDate(roles, date);
+  }
 }


### PR DESCRIPTION
## Description 

This PR introduces the `EmployeesStatusWidget` component, which is necessary to provide the administrator with insights about the daily employees and their work status. Key changes include: 

#### Backend
- Implemented query to fetch all schedules by date, only for `Moderator` and `Admin` roles. 
- Changed `schedule` entities to include `User` data.

#### Frontend
- Added `ScheduleStatuses` translations for string statuses
- Implemented `EmployeeStatusWidget` for `Dashboard` which displays all employees and their statuses for the current date. 
  - The day can be changed with the help buttons, and new data are fetched for that date.
  - The user can reset the calendar to display the current date, using the reset button.

## Screenshots

**Employees Status widget**
![image](https://github.com/user-attachments/assets/c6af0ec3-6d02-4d46-b0ed-503189e0d5b3)

**Current Dashboard state**
![image](https://github.com/user-attachments/assets/0c346404-5b97-4075-9684-796e1790895e)
