### PR TITLE
Implement client reservation cancellation through link

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import { UserRole } from "@core/types";
 import NotificationProvider from "@context/Notification";
 import CustomerManagementPage from "@pages/CustomerManagement/CustomerManagement";
 import SettingsPage from "@pages/Settings/Settings";
+import CancellationPage from "@pages/Cancellation/Cancellation";
 
 const router = createBrowserRouter([
   {
@@ -84,6 +85,10 @@ const router = createBrowserRouter([
           {
             path: "/unauthorized",
             element: <Unauthorized />
+          },
+          {
+            path: "/cancelReservation",
+            element: <CancellationPage />
           }
         ]
       }

--- a/client/src/pages/Cancellation/Cancellation.tsx
+++ b/client/src/pages/Cancellation/Cancellation.tsx
@@ -1,0 +1,37 @@
+import { useNotification } from "@context/Notification";
+import { postReq } from "@core/utils";
+import { Button } from "@heroui/react";
+import { useMutation } from "@tanstack/react-query";
+import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
+
+export default function CancellationPage() {
+    const [ URLSearchParams ] = useSearchParams();
+    const uuid = URLSearchParams.get("uuid");
+    const navigate = useNavigate();
+    const { notify } = useNotification();
+
+    const { mutateAsync: cancel, isPending } = useMutation({
+        mutationFn: (cancellationUUID: string) => postReq(`/cancelReservation/${cancellationUUID}`),
+        onSuccess: () => notify({ message: "Reservation has been cancelled successfully.", type: "success" }),
+        onError: () => notify({ message: "Reservation could not be cancelled", type: "danger" }),
+        onSettled: () => navigate("/")
+    });
+
+    if (uuid === null) {
+        return <Navigate to="/" />
+    }
+
+    async function handleCancel() {
+        if (uuid === null) { return; }
+        await cancel(uuid);
+    }
+
+    return (
+        <div className="flex items-center justify-center flex-col mt-5">
+            <div className="gap-2 mt-5 flex items-center justify-center flex-col">
+                <h3 className="text-lg">Please confirm the cancellation of your reservation</h3>
+                <Button color="danger" onPress={handleCancel} isLoading={isPending}>Cancel Reservation</Button>
+            </div>
+        </div>
+    )
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/GeneralController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/GeneralController.java
@@ -1,0 +1,35 @@
+package com.kalyvianakis.estiator.io.controller;
+
+import com.kalyvianakis.estiator.io.model.Reservation;
+import com.kalyvianakis.estiator.io.model.Response;
+import com.kalyvianakis.estiator.io.service.ReservationService;
+import com.kalyvianakis.estiator.io.utils.ResourceNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Controller that handles all root level URIs that cannot be mapped to other, more specific controllers
+ */
+@RestController
+@CrossOrigin
+@RequestMapping("/")
+public class GeneralController {
+    @Autowired
+    ReservationService reservationService;
+
+    @PostMapping("/cancelReservation/{uuid}")
+    public ResponseEntity<?> cancelReservation(@PathVariable String uuid) throws ResourceNotFoundException {
+        if (!reservationService.exists(uuid)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        Response response = new Response();
+        Reservation reservation = reservationService.get(uuid);
+        reservationService.cancel(reservation);
+        response.setMessage("Your reservation has been cancelled successfully");
+        response.setDetails("Reservation with ID: " + reservation.getId() + " has been cancelled successfully.");
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/ReservationController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/ReservationController.java
@@ -3,10 +3,12 @@ package com.kalyvianakis.estiator.io.controller;
 import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import com.kalyvianakis.estiator.io.dto.ReservationRequest;
 import com.kalyvianakis.estiator.io.enums.ReservationStatus;
 import com.kalyvianakis.estiator.io.enums.UserStatus;
+import com.kalyvianakis.estiator.io.model.Response;
 import com.kalyvianakis.estiator.io.model.User;
 import com.kalyvianakis.estiator.io.service.EmailSenderService;
 import com.kalyvianakis.estiator.io.service.TableService;
@@ -83,6 +85,9 @@ public class ReservationController {
       reservation.setTable(request.getTable());
       reservation.setTime(request.getTime());
       reservation.setDuration(request.getDuration());
+
+      UUID cancellationUUID = UUID.randomUUID();
+      reservation.setCancellationUUID(cancellationUUID.toString());
 
       List<Short> statuses = List.of(ReservationStatus.Confirmed.getLabel());
 
@@ -210,5 +215,4 @@ public class ReservationController {
         }
         return ResponseEntity.ok().build();
     }
-  
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/model/Reservation.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/model/Reservation.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -42,6 +43,8 @@ public class Reservation extends PropertyPrinter {
 
   private Integer duration;
 
+  private String cancellationUUID;
+
   @Transient
   private Integer conflicts;
 
@@ -67,7 +70,6 @@ public class Reservation extends PropertyPrinter {
 
   @Transient
   private LocalTime endTime;
-
 
   public Reservation(LocalDate date, LocalTime time, ReservationStatus status, Table table, User createdBy, User createdFor) {
     this.date = date;
@@ -199,5 +201,13 @@ public class Reservation extends PropertyPrinter {
 
   public void setEndTime(LocalTime endTime) {
     this.endTime = endTime;
+  }
+
+  public String getCancellationUUID() {
+    return cancellationUUID;
+  }
+
+  public void setCancellationUUID(String cancellationUUID) {
+    this.cancellationUUID = cancellationUUID;
   }
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/model/Response.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/model/Response.java
@@ -4,6 +4,7 @@ public class Response {
     private String message;
     private String details;
 
+    public Response() {}
     public Response(String message, String details) {
         this.message = message;
         this.details = details;

--- a/server/src/main/java/com/kalyvianakis/estiator/io/repository/ReservationRepository.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/repository/ReservationRepository.java
@@ -15,11 +15,14 @@ import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.UUID;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     Long countByDateLessThanEqual(LocalDate date);
     Long countByDateBetween(LocalDate from, LocalDate to);
+    Boolean existsByCancellationUUID(String cancellationUUID);
+    Reservation findByCancellationUUID(String cancellationUUID);
 
     @Query(
             value = "SELECT\n" +

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/EmailSenderService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/EmailSenderService.java
@@ -53,7 +53,8 @@ public class EmailSenderService {
                 reservation.getTime().toString(),
                 reservation.getTime().plusSeconds(reservation.getDuration()).toString(),
                 tableLabel,
-                reservation.getPersons()
+                reservation.getPersons(),
+                reservation.getCancellationUUID()
         );
 
         this.sendMessage(
@@ -75,7 +76,8 @@ public class EmailSenderService {
                 reservation.getTime().toString(),
                 reservation.getTime().plusSeconds(reservation.getDuration()).toString(),
                 tableLabel,
-                reservation.getPersons()
+                reservation.getPersons(),
+                reservation.getCancellationUUID()
         );
 
         this.sendMessage(
@@ -121,7 +123,8 @@ public class EmailSenderService {
                 reservation.getTime().toString(),
                 reservation.getTime().plusSeconds(reservation.getDuration()).toString(),
                 tableLabel,
-                reservation.getPersons()
+                reservation.getPersons(),
+                reservation.getCancellationUUID()
         );
 
         this.sendMessage(

--- a/server/src/main/java/com/kalyvianakis/estiator/io/service/ReservationService.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/service/ReservationService.java
@@ -1,18 +1,15 @@
 package com.kalyvianakis.estiator.io.service;
 
-import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 
 import com.kalyvianakis.estiator.io.enums.ReservationStatus;
 import com.kalyvianakis.estiator.io.utils.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.kalyvianakis.estiator.io.model.Reservation;
 import com.kalyvianakis.estiator.io.repository.ReservationRepository;
-import org.springframework.web.bind.annotation.PathVariable;
 
 @Service
 public class ReservationService implements IReservationService {
@@ -67,6 +64,10 @@ public class ReservationService implements IReservationService {
     return reservationRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("Reservation not found for ID: " + id));
   }
 
+  public Reservation get(String cancellationUUID) {
+    return reservationRepository.findByCancellationUUID(cancellationUUID);
+  }
+
   public Long getCount() {
     return reservationRepository.count();
   }
@@ -88,6 +89,7 @@ public class ReservationService implements IReservationService {
   public Boolean exists(Long id) {
     return reservationRepository.existsById(id);
   }
+  public Boolean exists(String cancellationUUID) { return reservationRepository.existsByCancellationUUID(cancellationUUID); }
 
   @Override
   public Boolean notExists(Long id) {

--- a/server/src/main/java/com/kalyvianakis/estiator/io/utils/ApplicationProperties.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/utils/ApplicationProperties.java
@@ -9,11 +9,48 @@ import org.springframework.context.annotation.Configuration;
 public class ApplicationProperties {
     private String jwtSecret;
 
+    private String clientProtocol;
+
+    private String clientPort;
+
+    private String clientHost;
+
+    public String getClientUrl() {
+        return clientProtocol + "://" + clientHost + (!clientPort.isEmpty() ? ":" + clientPort : "") + "/";
+    }
+    public String getClientUrl(String append) {
+        return getClientUrl() + append;
+    }
+
     public String getJwtSecret() {
         return jwtSecret;
     }
 
     public void setJwtSecret(String jwtSecret) {
         this.jwtSecret = jwtSecret;
+    }
+
+    public String getClientProtocol() {
+        return clientProtocol;
+    }
+
+    public void setClientProtocol(String clientProtocol) {
+        this.clientProtocol = clientProtocol;
+    }
+
+    public String getClientPort() {
+        return clientPort;
+    }
+
+    public void setClientPort(String clientPort) {
+        this.clientPort = clientPort;
+    }
+
+    public String getClientHost() {
+        return clientHost;
+    }
+
+    public void setClientHost(String clientHost) {
+        this.clientHost = clientHost;
     }
 }

--- a/server/src/main/java/com/kalyvianakis/estiator/io/utils/config/SecurityConfig.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/utils/config/SecurityConfig.java
@@ -59,6 +59,9 @@ public class SecurityConfig {
 
                         .requestMatchers(HttpMethod.GET ,"/users/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_MODERATOR")
                         .requestMatchers(HttpMethod.PATCH ,"/users/**").hasAnyAuthority("ROLE_ADMIN", "ROLE_MODERATOR")
+
+                        .requestMatchers(HttpMethod.POST, "/cancelReservation/**").permitAll()
+
                         .requestMatchers("/users/**").hasAuthority("ROLE_ADMIN")
 
                         .requestMatchers("/schedules/**").hasAuthority("ROLE_ADMIN")

--- a/server/src/main/java/com/kalyvianakis/estiator/io/utils/config/SimpleMailMessageExt.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/utils/config/SimpleMailMessageExt.java
@@ -1,5 +1,7 @@
 package com.kalyvianakis.estiator.io.utils.config;
 
+import com.kalyvianakis.estiator.io.utils.ApplicationProperties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -10,6 +12,9 @@ import java.util.Properties;
 
 @Component
 public class SimpleMailMessageExt extends SimpleMailMessage {
+
+    @Autowired
+    ApplicationProperties applicationProperties;
 
     @Bean
     public JavaMailSender getJavaMailSender() {
@@ -35,12 +40,13 @@ public class SimpleMailMessageExt extends SimpleMailMessage {
     @Bean
     public SimpleMailMessage templateCreateReservation() {
         SimpleMailMessage message = new SimpleMailMessage();
+        String cancellationUrl = applicationProperties.getClientUrl("cancelReservation?uuid=%s");
 
         message.setText("Hello %s,\n\nA new reservation in %s has been created for you!\n\n" +
                 "Below you can find more details about your reservation: \n\nDate: %s\nFrom: %s\nUntil: %s\nTable preference: %s\nPersons: %d\n\n" +
                 "Please note that the reservation is not yet finalized. Our staff will soon confirm it, so please wait.\n\n\n" +
                 "If you would like to cancel this reservation, you can click the link below:\n" +
-                "http://estiator.io");
+                cancellationUrl);
 
         return message;
     }
@@ -48,11 +54,12 @@ public class SimpleMailMessageExt extends SimpleMailMessage {
     @Bean
     public SimpleMailMessage templateConfirmReservation() {
         SimpleMailMessage message = new SimpleMailMessage();
+        String cancellationUrl = applicationProperties.getClientUrl("cancelReservation?uuid=%s");
 
         message.setText("Hello %s,\n\nYour reservation in %s has be confirmed!\n\n" +
                 "Below you can find the final details of your reservation: \n\nDate: %s\nFrom: %s\nUntil: %s\nTable preference: %s\nPersons: %d\n\n\n" +
                 "If you would like to cancel this reservation, you can click the link below:\n" +
-                "http://estiator.io");
+                cancellationUrl);
 
         return message;
     }
@@ -71,11 +78,12 @@ public class SimpleMailMessageExt extends SimpleMailMessage {
     @Bean
     public SimpleMailMessage templateEditReservation() {
         SimpleMailMessage message = new SimpleMailMessage();
+        String cancellationUrl = applicationProperties.getClientUrl("cancelReservation?uuid=%s");
 
         message.setText("Hello %s,\n\nYour reservation info in %s have been updated.\n\n" +
                 "Some information regarding your reservation have been changed. Below you can find the updated reservation details: \n\nStatus: %s\nDate: %s\nFrom: %s\nUntil: %s\nTable preference: %s\nPersons: %d\n\n\n" +
                 "If you would like to cancel this reservation, you can click the link below:\n" +
-                "http://estiator.io");
+                cancellationUrl);
 
         return message;
     }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -24,3 +24,8 @@ server.ssl.enabled=true
 trust.store=classpath:keystore/estiator.p12
 #trust store password
 trust.store.password=${SSL_KEYSTORE_PASSWORD}
+
+# Information regarding client using the API (for usage in email sending)
+app.client-host=192.168.1.194
+app.client-port=8080
+app.client-protocol=http


### PR DESCRIPTION
## Description  
This PR implements client-side reservation cancellation through a unique cancellation link. It introduces a new cancellation page, updates email templates with cancellation links, and modifies backend logic to support secure reservation cancellations.  

### List of Changes:  
- **Frontend Changes:**  
  - Added `CancellationPage` to handle reservation cancellations from a provided link.  

- **Backend Changes:**  
  - Added `cancellationUUID` field to the `Reservation` model.  
  - Implemented `cancellationUUID` handling in the Reservation service and repository.  
  - Generated `cancellationUUID` in `ReservationController`.  
  - Added `GeneralController` to handle root-level reservation cancellations.  
  - Allowed all users to access the `cancelReservation` endpoint.  
  - Prevented the re-cancellation of a reservation after it has already been cancelled.

- **Email & Configuration Updates:**  
  - Updated email templates to include cancellation links.  
  - Injected `ApplicationProperties` into `SimpleMailMessageExt` for dynamic link generation.  
  - Added client configuration properties and methods to `ApplicationProperties`.  
  - Added automatic email to inform client regarding the cancellation

## Screenshots  

**Received mail on reservation creation**
![image](https://github.com/user-attachments/assets/e8309150-ef90-4910-93de-54ca04d08c42)

**Cancellation page**
![image](https://github.com/user-attachments/assets/dc43b627-b50b-4cd8-acbe-666dc6cdc3bc)
