### PR TITLE
Fix issue with reservation re-cancellations

### DIFF
--- a/server/src/main/java/com/kalyvianakis/estiator/io/controller/GeneralController.java
+++ b/server/src/main/java/com/kalyvianakis/estiator/io/controller/GeneralController.java
@@ -1,7 +1,10 @@
 package com.kalyvianakis.estiator.io.controller;
 
+import com.kalyvianakis.estiator.io.enums.ReservationStatus;
+import com.kalyvianakis.estiator.io.model.ErrorResponse;
 import com.kalyvianakis.estiator.io.model.Reservation;
 import com.kalyvianakis.estiator.io.model.Response;
+import com.kalyvianakis.estiator.io.service.EmailSenderService;
 import com.kalyvianakis.estiator.io.service.ReservationService;
 import com.kalyvianakis.estiator.io.utils.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,17 +21,28 @@ public class GeneralController {
     @Autowired
     ReservationService reservationService;
 
+    @Autowired
+    EmailSenderService senderService;
+
     @PostMapping("/cancelReservation/{uuid}")
     public ResponseEntity<?> cancelReservation(@PathVariable String uuid) throws ResourceNotFoundException {
         if (!reservationService.exists(uuid)) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(new ErrorResponse("Reservation with UUID: " + uuid + " does not exist", ""));
         }
+
 
         Response response = new Response();
         Reservation reservation = reservationService.get(uuid);
+
+        if (reservation.getStatus() == ReservationStatus.Cancelled) {
+            return ResponseEntity.badRequest().body(new ErrorResponse("Reservation is already cancelled", ""));
+        }
+
         reservationService.cancel(reservation);
         response.setMessage("Your reservation has been cancelled successfully");
-        response.setDetails("Reservation with ID: " + reservation.getId() + " has been cancelled successfully.");
+        response.setDetails("");
+
+        senderService.sendReservationCancelled(reservation, "Reservation has been cancelled by client");
 
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
### Description

This PR fixes an issue that is occuring when a client clicks the cancellation url to cancel his reservation when it is already cancelled. With this PR the server returns an erroneous (Bad Request) response to indicate that the reservation has already been cancelled. 

Also when the reservation is not found, the server responds accordingly. 